### PR TITLE
Set minimum supported Python version to 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 package_dir =
 	= src
 include_package_data = true
-python_requires = >=3.7
+python_requires = >=3.6
 install_requires =
 	tomlkit
 


### PR DESCRIPTION
In discussion #2, we determined that we want this package to be as widely compatible as is reasonable. Since most people are only going to use it once (or, once per package they maintain), keeping up with the latest supported Python release isn't that important, and if we require a newer version than what a package maintainer is already using, that might be enough of a barrier to discourage someone from using it. Setting the minimum version at 3.5 allows us to use type hints, so I'm implementing that here. If we find a reason that we need to restrict it to 3.6 and up, we can always change it later.