### PR TITLE
Configure linters and fix issues detected

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,28 +1,28 @@
 extensions = [
-    'sphinx.ext.autodoc',
-    'jaraco.packaging.sphinx',
+    "sphinx.ext.autodoc",
+    "jaraco.packaging.sphinx",
 ]
 
 master_doc = "index"
 html_theme = "furo"
 
 # Link dates and other references in the changelog
-extensions += ['rst.linker']
+extensions += ["rst.linker"]
 link_files = {
-    '../CHANGES.rst': dict(
-        using=dict(GH='https://github.com'),
+    "../CHANGES.rst": dict(
+        using=dict(GH="https://github.com"),
         replace=[
             dict(
-                pattern=r'(Issue #|\B#)(?P<issue>\d+)',
-                url='{package_url}/issues/{issue}',
+                pattern=r"(Issue #|\B#)(?P<issue>\d+)",
+                url="{package_url}/issues/{issue}",
             ),
             dict(
-                pattern=r'(?m:^((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n)',
-                with_scm='{text}\n{rev[timestamp]:%d %b %Y}\n',
+                pattern=r"(?m:^((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n)",
+                with_scm="{text}\n{rev[timestamp]:%d %b %Y}\n",
             ),
             dict(
-                pattern=r'PEP[- ](?P<pep_number>\d+)',
-                url='https://peps.python.org/pep-{pep_number:0>4}/',
+                pattern=r"PEP[- ](?P<pep_number>\d+)",
+                url="https://peps.python.org/pep-{pep_number:0>4}/",
             ),
         ],
     )
@@ -33,9 +33,9 @@ nitpicky = True
 
 # Include Python intersphinx mapping to prevent failures
 # jaraco/skeleton#51
-extensions += ['sphinx.ext.intersphinx']
+extensions += ["sphinx.ext.intersphinx"]
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
+    "python": ("https://docs.python.org/3", None),
 }
 
 # Preserve authored syntax for defaults

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-# required to support namespace packages
-# https://github.com/python/mypy/issues/14057
-explicit_package_bases = True
+namespace_packages = False
+mypy_path = $MYPY_CONFIG_FILE_DIR/src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,14 @@ exclude = '''
 )
 '''
 
+[tool.ruff]
+line-length = 120
+src = ["src"]
+# Ruff is capable of inferring this from project.requires-python, but we don't
+# set that because we keep our project configuration in setup.cfg, so list it
+# explicitly here.
+target-version = "py36"
+
 [tool.setuptools_scm]
 
 [tool.pytest-enabler.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,21 @@ requires = ["setuptools>=56", "setuptools_scm[toml]>=3.4.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-skip-string-normalization = true
+line-length = 120
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.tox
+    | \.venv
+    | __pycache__
+    | .+\.egg-info
+    | build
+    | dist
+  )
+)
+'''
 
 [tool.setuptools_scm]
 

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -1,10 +1,12 @@
 import setuptools
 import sys
 import tomlkit
+from typing import List, Optional, Tuple
 
 
 class WritePyproject(setuptools.Command):
-    user_options = []
+    # Each option tuple contains (long name, short name, help string)
+    user_options: List[Tuple[str, Optional[str], str]] = []
 
     def initialize_options(self):
         pass


### PR DESCRIPTION
In this PR I've added or updated configuration for all the static linters (black, mypy, ruff) and fixed any errors detected (at least on Python 3.10 which is the only one I'm currently able to run... working on that).

This will pave the way to adding pre-commit hooks to run those linters, but I decided to leave that for a separate PR.