### PR TITLE
Add setuptools as an explicit dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ package_dir =
 include_package_data = true
 python_requires = >=3.7
 install_requires =
+	setuptools
 	tomlkit
 
 [options.packages.find]


### PR DESCRIPTION
I'm so used to setuptools only being required for building packages that I forgot in this case we actually depend on it directly. So I'm adding it as an explicit runtime dependency.