### PR TITLE
Update development status to pre-alpha

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ description = Create a pyproject.toml file from setuptools configuration
 long_description = file:README.rst
 url = https://github.com/diazona/setuptools-pyproject-migration
 classifiers =
-	Development Status :: 1 - Planning
+	Development Status :: 2 - Pre-Alpha
 	Environment :: Plugins
 	Framework :: Setuptools Plugin
 	Intended Audience :: Developers


### PR DESCRIPTION
I'm going basically by the explanations in [this blog post](https://martin-thoma.com/software-development-stages/). Since we are working on developing the initial functional version of the package, pre-alpha seems appropriate.