### PR TITLE
Make the documentation build successfully

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ nitpicky = True
 extensions += ["sphinx.ext.intersphinx"]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "setuptools": ("https://setuptools.pypa.io/en/latest/", None),
 }
 
 # Preserve authored syntax for defaults

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to |project| documentation!
    history
 
 
-.. automodule:: PROJECT
+.. automodule:: setuptools_pyproject_migration
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Welcome to |project| documentation!
+Welcome to |setuptools-pyproject-migration| documentation!
 ===================================
 
 .. toctree::


### PR DESCRIPTION
In this commit I'm fixing a couple small errors that prevented the documentation from building: I added the actual name of the project module, and I added an Intersphinx mapping for setuptools so that sphinx can look up documentation for setuptools classes.

The documentation still doesn't have much of anything useful but this at least should allow the CI job to pass, then we can continue to iterate on the documentation content itself without fear of breaking it.