### PR TITLE
Update .editorconfig file for consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,14 +2,14 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = tab
+indent_style = space
 indent_size = 4
 insert_final_newline = true
 end_of_line = lf
 
 [*.py]
 indent_style = space
-max_line_length = 88
+max_line_length = 120
 
 [*.{yml,yaml}]
 indent_style = space


### PR DESCRIPTION
The file `.editorconfig` defines settings that can be used by various text editors, according to the specification at https://editorconfig.org/. I don't use it myself, but if anyone does, the settings there should be consistent with what we've given in the configurations of other linters, so in this commit I'm updating the line length and indentation mode to match usage and configuration in the rest of the project.