### PR TITLE
Add pre-commit hooks for remaining linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,13 @@ repos:
     # change detection by pre-commit
     #- "--exit-non-zero-on-fix"
 
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.4.1
+  hooks:
+  - id: mypy
+    additional_dependencies:
+    - setuptools
+
 - repo: https://github.com/psf/black
   rev: 22.6.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,15 @@
 repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Last version of ruff which will accept "py36" as target-version
+  rev: v0.0.233
+  hooks:
+  - id: ruff
+    args:
+    - "--fix"
+    # When updating to ruff v0.0.244 or higher, this can be enabled to improve
+    # change detection by pre-commit
+    #- "--exit-non-zero-on-fix"
+
 - repo: https://github.com/psf/black
   rev: 22.6.0
   hooks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,11 +48,7 @@ class Project:
         try:
             file.relative_to(self.root)
         except ValueError:
-            warnings.warn(
-                "Writing to path {} which is not under project root {}".format(
-                    file, self.root
-                )
-            )
+            warnings.warn("Writing to path {} which is not under project root {}".format(file, self.root))
         if file.exists() and not file.is_dir():
             # This warning message is confusing if the file is a directory, so just go
             # ahead and let the write_text() call fail in that case


### PR DESCRIPTION
I'm adding pre-commit hooks for ruff and mypy, which will make it easier to not introduce code that would fail those checks. The pre-commit hooks just run the same commits we have already been running as part of CI, so there's no change to the configuration of those tools.