### PR TITLE
Revert "Change one instance of project name that I missed"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Welcome to |setuptools-pyproject-migration| documentation!
+Welcome to |project| documentation!
 ===================================
 
 .. toctree::


### PR DESCRIPTION
This reverts commit 01ff329ab5dbf2e89b32f21ca71abc428a352aed. In that commit I changed what I thought was a hard-coded instance of the project name, but it was actually a placeholder that will be replaced with the real project name during documentation generation. That change caused docs generation to fail, and I shouldn't have changed it, so I'm reverting it now.