### PR TITLE
Skip duplicate actions when pushing in this repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,10 @@ jobs:
         - python: pypy3.9
           platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
+    # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     continue-on-error: ${{ matrix.python == '3.12' }}
     steps:
       - uses: actions/checkout@v3
@@ -77,6 +81,10 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     env:
       TOXENV: docs
     steps:
@@ -92,7 +100,10 @@ jobs:
         run: tox
 
   check:  # This job does nothing and is only used for the branch protection
-    if: always()
+    # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     needs:
     - test


### PR DESCRIPTION
Currently when creating a pull request (at least, one not in a fork, but at the moment there are no forks anyway), we get two copies of each Github action, one for the branch push and one for the pull request. The change in this commit should skip the action running for the pull request whenever the source branch exists locally in this repository. It shouldn't affect branches coming from other people's forks, if there are forks in the future.

I copied the logic to do this from another project in which I [worked out how to do the same thing](https://github.com/pytest-dev/pytest-localserver/pull/45). The comment I've added to the workflow refers to [a blog post](https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/) I relied on when figuring out how to make this work for that other project.