### PR TITLE
Tweak some project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Ignore vi swapfiles
+*.swp
+.*.swp
+
+# Ignore Python cache directories
+__pycache__/
+
+# Ignore project coverage
+.coverage
+
+# Ignore tox working directory
+.tox/
+
+# Ignore "egg info" directories
+*.egg-info
+
+# Ignore the 'env' directory, may be used by developers for a local test
+# environment within the project workspace.
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,28 @@
-# Ignore vi swapfiles
-*.swp
-.*.swp
+# NB: please avoid putting environment specific rules here.  Many of these settings can be put in
+# ${HOME}/.config/git/ignore (aka ${XDG_CONFIG_HOME}/git/config, Windows users perhaps try AppData\Local?) -- then they
+# apply to all projects on your local workstation.
+#
+# Examples:
+# - vi swapfiles (*.sw?, .*.sw?)
+# - IntelliJ IDEA project (.idea/)
+# - VisualStudio Code project (.vscode/)
+#
+# See https://git-scm.com/docs/gitignore for further detail.
+
+# Distribution generated files
+/dist/
+
+# Build system generated files
+/build/
 
 # Ignore Python cache directories
 __pycache__/
 
 # Ignore project coverage
-.coverage
+/.coverage
 
 # Ignore tox working directory
-.tox/
+/.tox/
 
-# Ignore "egg info" directories
+# Ignore "egg info" directories (or files, if someone makes such an abomination)
 *.egg-info
-
-# Ignore the 'env' directory, may be used by developers for a local test
-# environment within the project workspace.
-env/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs=dist build .tox .eggs
-addopts=--doctest-modules
+addopts=-v --doctest-modules
 filterwarnings=
 	## upstream
 


### PR DESCRIPTION
* Add a `.gitignore` so that generated or temporary files are not accidentally committed.
* Run `pytest` in verbose mode so that on test failures, it dumps the full `diff` where mismatches were detected in the output.