### PR TITLE
Implement emitting of some project dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ package_dir =
 include_package_data = true
 python_requires = >=3.6
 install_requires =
+	pep508-parser
 	setuptools
 	tomlkit
 

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -39,7 +39,7 @@ class WritePyproject(setuptools.Command):
 
         pyproject = {
             "build-system": {
-                "requires": list(sorted(setup_requirements)),
+                "requires": sorted(setup_requirements),
                 "build-backend": "setuptools.build_meta",
             }
         }
@@ -50,7 +50,7 @@ class WritePyproject(setuptools.Command):
         }
 
         # NB: ensure a consistent alphabetical ordering of dependencies
-        dependencies = list(sorted(set(dist.install_requires)))
+        dependencies = sorted(set(dist.install_requires))
         if dependencies:
             pyproject["project"]["dependencies"] = dependencies
 

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -1,6 +1,7 @@
 import setuptools
 import sys
 import tomlkit
+from pep508_parser import parser as pep508
 from typing import List, Optional, Tuple
 
 
@@ -17,9 +18,28 @@ class WritePyproject(setuptools.Command):
     def run(self):
         dist: setuptools.dist.Distribution = self.distribution
 
+        # pyproject.toml schema:
+        # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata
+
+        # Enumerate all set-up and build requirements, ensure there are no duplicates
+        setup_requirements = set(dist.setup_requires)
+
+        # Is 'setuptools' already there?
+        seen_setuptools = False
+        for dep in setup_requirements:
+            (dep_module, _, _, _) = pep508.parse(dep)
+            if dep_module == "setuptools":
+                # Yep, here it is!
+                seen_setuptools = True
+                break
+
+        if not seen_setuptools:
+            # We will need it here
+            setup_requirements.add("setuptools")
+
         pyproject = {
             "build-system": {
-                "requires": ["setuptools"],
+                "requires": list(sorted(setup_requirements)),
                 "build-backend": "setuptools.build_meta",
             }
         }
@@ -28,5 +48,10 @@ class WritePyproject(setuptools.Command):
             "name": dist.get_name(),
             "version": dist.get_version(),  # TODO try to reverse-engineer dynamic version
         }
+
+        # NB: ensure a consistent alphabetical ordering of dependencies
+        dependencies = list(sorted(set(dist.install_requires)))
+        if dependencies:
+            pyproject["project"]["dependencies"] = dependencies
 
         tomlkit.dump(pyproject, sys.stdout)

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -25,15 +25,9 @@ class WritePyproject(setuptools.Command):
         setup_requirements = set(dist.setup_requires)
 
         # Is 'setuptools' already there?
-        seen_setuptools = False
-        for dep in setup_requirements:
-            (dep_module, _, _, _) = pep508.parse(dep)
-            if dep_module == "setuptools":
-                # Yep, here it is!
-                seen_setuptools = True
-                break
+        has_setuptools = any(pep508.parse(dep)[0] == "setuptools" for dep in setup_requirements)
 
-        if not seen_setuptools:
+        if not has_setuptools:
             # We will need it here
             setup_requirements.add("setuptools")
 

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -1,4 +1,7 @@
 def test_name_and_version(project) -> None:
+    """
+    Test we can generate a basic project skeleton.
+    """
     setup_cfg = """\
 [metadata]
 name = test-project
@@ -7,6 +10,140 @@ version = 0.0.1
     pyproject_toml = """\
 [build-system]
 requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-project"
+version = "0.0.1"
+"""
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.run()
+    assert result.returncode == 0
+    assert result.stdout == "running pyproject\n" + pyproject_toml
+
+
+# install_requires tests, we use made-up module names here.
+
+
+def test_install_requires(project) -> None:
+    """
+    Test the install_requires is passed through if given.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+install_requires =
+        dependency1
+        dependency2>=1.23
+        dependency3<4.56
+"""
+    pyproject_toml = """\
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-project"
+version = "0.0.1"
+dependencies = ["dependency1", "dependency2>=1.23", "dependency3<4.56"]
+"""
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.run()
+    assert result.returncode == 0
+    assert result.stdout == "running pyproject\n" + pyproject_toml
+
+
+# setup_requires tests: we have to use real dependencies that actually are
+# installed, otherwise the tests will fail.
+
+
+def test_setup_requires(project) -> None:
+    """
+    Test setup_requires is passed through with 'setuptools' dependency.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+setup_requires =
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+"""
+    pyproject_toml = """\
+[build-system]
+requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-project"
+version = "0.0.1"
+"""
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.run()
+    assert result.returncode == 0
+    assert result.stdout == "running pyproject\n" + pyproject_toml
+
+
+def test_setup_requires_setuptools(project) -> None:
+    """
+    Test that we don't duplicate 'setuptools' in build requirements
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+setup_requires =
+        setuptools
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+"""
+    pyproject_toml = """\
+[build-system]
+requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-project"
+version = "0.0.1"
+"""
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.run()
+    assert result.returncode == 0
+    assert result.stdout == "running pyproject\n" + pyproject_toml
+
+
+def test_setup_requires_setuptools_version(project) -> None:
+    """
+    Test we can handle a build system that requires a specific setuptools version.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+setup_requires =
+        setuptools>=34.56
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+"""
+    pyproject_toml = """\
+[build-system]
+requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools>=34.56", "sphinx"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -8,13 +8,9 @@ def check_result(result, reference, prefix="running pyproject\n"):
     assert result.returncode == 0
     assert result.stdout.startswith(prefix)
 
-    # Parse the reference in case of formatting differences
     reference_parsed = tomlkit.parse(reference)
-
-    # Parse the resultant text:
     result_parsed = tomlkit.parse(result.stdout[len(prefix) :])
 
-    # Assert equivalence
     assert result_parsed == reference_parsed
 
 

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -1,3 +1,23 @@
+import tomlkit
+
+
+def check_result(result, reference, prefix="running pyproject\n"):
+    """
+    Check the result succeeded, and matches the expected output.
+    """
+    assert result.returncode == 0
+    assert result.stdout.startswith(prefix)
+
+    # Parse the reference in case of formatting differences
+    reference_parsed = tomlkit.parse(reference)
+
+    # Parse the resultant text:
+    result_parsed = tomlkit.parse(result.stdout[len(prefix) :])
+
+    # Assert equivalence
+    assert result_parsed == reference_parsed
+
+
 def test_name_and_version(project) -> None:
     """
     Test we can generate a basic project skeleton.
@@ -19,8 +39,7 @@ version = "0.0.1"
     project.setup_cfg(setup_cfg)
     project.setup_py()
     result = project.run()
-    assert result.returncode == 0
-    assert result.stdout == "running pyproject\n" + pyproject_toml
+    check_result(result, pyproject_toml)
 
 
 # install_requires tests, we use made-up module names here.
@@ -54,8 +73,7 @@ dependencies = ["dependency1", "dependency2>=1.23", "dependency3<4.56"]
     project.setup_cfg(setup_cfg)
     project.setup_py()
     result = project.run()
-    assert result.returncode == 0
-    assert result.stdout == "running pyproject\n" + pyproject_toml
+    check_result(result, pyproject_toml)
 
 
 # setup_requires tests: we have to use real dependencies that actually are
@@ -89,8 +107,7 @@ version = "0.0.1"
     project.setup_cfg(setup_cfg)
     project.setup_py()
     result = project.run()
-    assert result.returncode == 0
-    assert result.stdout == "running pyproject\n" + pyproject_toml
+    check_result(result, pyproject_toml)
 
 
 def test_setup_requires_setuptools(project) -> None:
@@ -121,8 +138,7 @@ version = "0.0.1"
     project.setup_cfg(setup_cfg)
     project.setup_py()
     result = project.run()
-    assert result.returncode == 0
-    assert result.stdout == "running pyproject\n" + pyproject_toml
+    check_result(result, pyproject_toml)
 
 
 def test_setup_requires_setuptools_version(project) -> None:
@@ -153,5 +169,4 @@ version = "0.0.1"
     project.setup_cfg(setup_cfg)
     project.setup_py()
     result = project.run()
-    assert result.returncode == 0
-    assert result.stdout == "running pyproject\n" + pyproject_toml
+    check_result(result, pyproject_toml)


### PR DESCRIPTION
This picks up `setup_requires` and `install_requires`, and puts those in the build dependencies and project dependencies TOML output.

If `setuptools` is already listed by the project, we avoid duplicating it.  Dependencies are also "normalised" in alphabetical order, with duplicates removed.