### PR TITLE
Add complete TOML type information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
 	pep508-parser
 	setuptools
 	tomlkit
+	typing-extensions >=4, <5
 
 [options.packages.find]
 exclude =
@@ -52,6 +53,7 @@ testing =
 	pytest-ruff
 
 	# local
+	types-setuptools
 
 docs =
 	# upstream

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -1,8 +1,18 @@
+import datetime
 import setuptools
 import sys
 import tomlkit
 from pep508_parser import parser as pep508
-from typing import List, Optional, Tuple
+from typing import List, Mapping, Optional, Sequence, Tuple, Union
+
+# After we drop support for Python <3.10, we can import TypeAlias directly from typing
+from typing_extensions import TypeAlias
+
+
+TOMLPrimitive: TypeAlias = Union[bool, int, float, str, datetime.datetime, datetime.date, datetime.time]
+TOMLArray: TypeAlias = Sequence["TOMLValue"]
+TOMLTable: TypeAlias = Mapping[str, "TOMLValue"]
+TOMLValue: TypeAlias = Union[TOMLPrimitive, TOMLArray, TOMLTable]
 
 
 class WritePyproject(setuptools.Command):
@@ -31,7 +41,7 @@ class WritePyproject(setuptools.Command):
             # We will need it here
             setup_requirements.add("setuptools")
 
-        pyproject = {
+        pyproject: TOMLTable = {
             "build-system": {
                 "requires": sorted(setup_requirements),
                 "build-backend": "setuptools.build_meta",
@@ -49,3 +59,6 @@ class WritePyproject(setuptools.Command):
             pyproject["project"]["dependencies"] = dependencies
 
         tomlkit.dump(pyproject, sys.stdout)
+
+
+__all__ = ["WritePyproject"]


### PR DESCRIPTION
This commit creates type aliases for the types involved in a structure that can be rendered to TOML. This will help us use mypy to ensure that we're not adding anything to the returned data structure that couldn't be written out in TOML format.

In order to help convince mypy that this doesn't introduce a type violation, I had to add the setuptools type stubs as a testing dependency.