### PR TITLE
Merge latest updates from jaraco/skeleton

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
-      - name: Run tests
+      - name: Run
         run: tox
 
   docs:
@@ -90,7 +90,7 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
-      - name: Run tests
+      - name: Run
         run: tox
 
   check:  # This job does nothing and is only used for the branch protection
@@ -128,7 +128,7 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
-      - name: Release
+      - name: Run
         run: tox -e release
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,19 +42,14 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.7"
+        - "3.8"
         - "3.11"
         - "3.12"
-        # Workaround for actions/setup-python#508
-        dev:
-        - -dev
         platform:
         - ubuntu-latest
         - macos-latest
         - windows-latest
         include:
-        - python: "3.8"
-          platform: ubuntu-latest
         - python: "3.9"
           platform: ubuntu-latest
         - python: "3.10"
@@ -72,7 +67,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}${{ matrix.dev }}
+          python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install tox
         run: |
           python -m pip install tox
@@ -91,8 +87,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}${{ matrix.dev }}
       - name: Install tox
         run: |
           python -m pip install tox
@@ -130,7 +124,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11-dev
+          python-version: 3.x
       - name: Install tox
         run: |
           python -m pip install tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ html_theme = "furo"
 # Link dates and other references in the changelog
 extensions += ["rst.linker"]
 link_files = {
-    "../CHANGES.rst": dict(
+    "../NEWS.rst": dict(
         using=dict(GH="https://github.com"),
         replace=[
             dict(

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,4 +5,4 @@
 History
 *******
 
-.. include:: ../CHANGES (links).rst
+.. include:: ../NEWS (links).rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Welcome to |project| documentation!
 ===================================
 
+.. sidebar-links::
+   :home:
+   :pypi:
+
 .. toctree::
    :maxdepth: 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,15 +28,3 @@ src = ["src"]
 target-version = "py36"
 
 [tool.setuptools_scm]
-
-[tool.pytest-enabler.black]
-addopts = "--black"
-
-[tool.pytest-enabler.mypy]
-addopts = "--mypy"
-
-[tool.pytest-enabler.cov]
-addopts = "--cov"
-
-[tool.pytest-enabler.ruff]
-addopts = "--ruff"

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ testing =
 docs =
 	# upstream
 	sphinx >= 3.5
-	jaraco.packaging >= 9
+	jaraco.packaging >= 9.3
 	rst.linker >= 1.9
 	furo
 	sphinx-lint

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ testing =
 	pytest-mypy >= 0.9.1; \
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"
-	pytest-enabler >= 1.3
+	pytest-enabler >= 2.2
 	pytest-ruff
 
 	# local

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,2 @@
+[tool.towncrier]
+title_format = "{version}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,3 @@
-[tox]
-toxworkdir={env:TOX_WORK_DIR:.tox}
-
-
 [testenv]
 deps =
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,4 @@
 [tox]
-envlist = python
-minversion = 3.2
-# https://github.com/jaraco/skeleton/issues/6
-tox_pip_extensions_ext_venv_update = true
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 
@@ -24,6 +20,16 @@ changedir = docs
 commands =
 	python -m sphinx -W --keep-going . {toxinidir}/build/html
 	python -m sphinxlint
+
+[testenv:finalize]
+skip_install = True
+deps =
+	towncrier
+	jaraco.develop >= 7.23
+passenv = *
+commands =
+	python -m jaraco.develop.finalize
+
 
 [testenv:release]
 skip_install = True


### PR DESCRIPTION
This PR pulls in the latest updates from https://github.com/jaraco/skeleton, adjusted to handle a few merge conflicts.

Notably, the update adds the use of [towncrier](https://towncrier.readthedocs.io/en/stable/tutorial.html) for generating a changelog, which we are not yet set up to take advantage of. I'll leave it for a future PR to either do that setup, or decide that we don't want to use it and remove the associated configuration file.