### PR TITLE
Test additional Python versions and dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
         # probably work on Mac and Windows too. But if an OS-specific bug does
         # slip through, we should catch it in pre-release testing.
         - ubuntu-latest
+        force-minimum-dependencies:
+        - false
         exclude:
         # Python 3.6 does not run on ubuntu-latest
         - python: "3.6"
@@ -34,10 +36,16 @@ jobs:
         include:
         - python: "3.6"
           platform: ubuntu-20.04
+          force-minimum-dependencies: false
+        # For testing forced minimum deps, use the latest stable version of Python
+        # on which those dependencies can be installed
+        - python: "3.11"
+          platform: ubuntu-latest
+          force-minimum-dependencies: true
     with:
       python-version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}
-
+      force-minimum-dependencies: ${{ matrix.force-minimum-dependencies }}
   docs:
     name: Build documentation
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,20 +16,24 @@ jobs:
     strategy:
       matrix:
         python:
+        - "3.6"
         - "3.8"
         - "3.11"
         - "3.12"
         platform:
+        # This package is supposed to be OS-independent and is unlikely to have
+        # OS-specific bugs, so we conserve runner usage by only testing on Linux
+        # during pre-merge and post-merge testing. If it works on Linux, it'll
+        # probably work on Mac and Windows too. But if an OS-specific bug does
+        # slip through, we should catch it in pre-release testing.
         - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        exclude:
+        # Python 3.6 does not run on ubuntu-latest
+        - python: "3.6"
+          platform: ubuntu-latest
         include:
-        - python: "3.9"
-          platform: ubuntu-latest
-        - python: "3.10"
-          platform: ubuntu-latest
-        - python: pypy3.9
-          platform: ubuntu-latest
+        - python: "3.6"
+          platform: ubuntu-20.04
     with:
       python-version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,47 @@ jobs:
     uses: ./.github/workflows/test.yml
     strategy:
       matrix:
+        # The idea here is to test with some key minor versions of Python on all
+        # platforms (Linux, Mac, Windows):
+        # - The oldest Python version supported by this package
+        # - The oldest non-EOL Python version
+        # - The newest stable Python version
+        # In addition, we test with all other CPython and PyPy versions but only
+        # on one platform. This package is supposed to be platform-independent
+        # so it's unlikely in the first place that we're going to find a bug on
+        # one platform that doesn't exist on another, and even more unlikely
+        # that such a bug would exist only in specific versions of Python.
+        #
+        # Of course if we ever do find such bugs, we should add additional
+        # matrix entries as necessary to ensure they are properly tested for.
         python:
+        - "3.6"
         - "3.8"
         - "3.11"
-        - "3.12"
         platform:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        exclude:
+        # Python 3.6 does not run on ubuntu-latest
+        - python: "3.6"
+          platform: ubuntu-latest
         include:
+        - python: "3.6"
+          platform: ubuntu-20.04
+        - python: "3.7"
+          platform: ubuntu-latest
         - python: "3.9"
           platform: ubuntu-latest
         - python: "3.10"
+          platform: ubuntu-latest
+        - python: "3.12"
+          platform: ubuntu-latest
+        - python: pypy3.6
+          platform: ubuntu-latest
+        - python: pypy3.7
+          platform: ubuntu-latest
+        - python: pypy3.8
           platform: ubuntu-latest
         - python: pypy3.9
           platform: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        force-minimum-dependencies:
+        - false
         exclude:
         # Python 3.6 does not run on ubuntu-latest
         - python: "3.6"
@@ -42,25 +44,44 @@ jobs:
         include:
         - python: "3.6"
           platform: ubuntu-20.04
+          force-minimum-dependencies: false
         - python: "3.7"
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: "3.9"
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: "3.10"
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: "3.12"
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: pypy3.6
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: pypy3.7
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: pypy3.8
           platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: pypy3.9
           platform: ubuntu-latest
+          force-minimum-dependencies: false
+        # For testing forced minimum deps, use both the earliest and latest stable
+        # (non-dev) versions of Python on which this package and the pinned
+        # dependencies can be installed
+        - python: "3.6"
+          platform: ubuntu-20.04
+          force-minimum-dependencies: true
+        - python: "3.11"
+          platform: ubuntu-latest
+          force-minimum-dependencies: true
     with:
       python-version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}
+      force-minimum-dependencies: ${{ matrix.force-minimum-dependencies }}
   docs:
     name: Build the documentation locally
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
       platform:
         type: string
         required: true
+      # Set this flag to test that the package works with the listed minimum
+      # versions of dependencies.
+      force-minimum-dependencies:
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -59,4 +65,7 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Run tests
-        run: tox -e py
+        # For simplicity, we limit forced minimum dependencies to direct
+        # dependencies and build system dependencies, not extra dependencies
+        # like pytest or sphinx.
+        run: tox -e py ${{ inputs.force-minimum-dependencies && '--force-dep setuptools==56 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4' || '' }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,9 @@ testing =
 		python_version >= "3.7"
 
 	# local
+	importlib-metadata; \
+		python_version < "3.8"
+	packaging
 	types-setuptools
 
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,10 @@ testing =
 	pytest-mypy >= 0.9.1; \
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"
-	pytest-enabler >= 2.2
-	pytest-ruff
+	pytest-enabler >= 2.2; \
+		python_version >= "3.8"
+	pytest-ruff; \
+		python_version >= "3.7"
 
 	# local
 	types-setuptools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import distutils.core
 import distutils.dist
+import packaging.version
 import pathlib
 import pytest
 import setuptools
@@ -7,6 +8,19 @@ import warnings
 from pytest_console_scripts import ScriptRunner
 from setuptools_pyproject_migration import Pyproject, WritePyproject
 from typing import Optional, Union
+
+try:
+    from importlib.metadata import version as im_version
+except ModuleNotFoundError:
+    # See https://github.com/python/mypy/issues/13914 for why we ignore the error here
+    from importlib_metadata import version as im_version  # type: ignore[no-redef]
+
+
+# Once we drop support for Python 3.6 we can probably remove this check since
+# pytest-console-scripts 1.4.0 supports Python 3.7
+_new_console_scripts = (
+    packaging.version.Version(im_version("pytest-console-scripts")) >= packaging.version.Version("1.4.0")  # fmt: skip
+)
 
 
 class Project:
@@ -94,7 +108,13 @@ setuptools.setup()
         """
         if not (self.root / "setup.py").exists():
             self.setup_py()
-        return self.script_runner.run(["setup.py", "pyproject"], cwd=self.root)
+        if _new_console_scripts:
+            return self.script_runner.run(["setup.py", "pyproject"], cwd=self.root)
+        else:
+            # pytest-console-scripts<1.4, which requires Python 3.7+, didn't
+            # support passing arguments as a list. Once we drop support for
+            # Python 3.6 we can discard this branch.
+            return self.script_runner.run("setup.py", "pyproject", cwd=self.root)
 
     def generate(self) -> Pyproject:
         """


### PR DESCRIPTION
This PR introduces tests for Python 3.6 and PyPy 3.7 and 3.8, as well as tests with the minimum declared versions of dependencies.

This depends on #22.