### PR TITLE
Refactor testing to use the data structure directly

### DIFF
--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -54,7 +54,11 @@ class WritePyproject(setuptools.Command):
     def finalize_options(self):
         pass
 
-    def run(self):
+    def _generate(self) -> Pyproject:
+        """
+        Create the raw data structure containing the information from
+        a pyproject.toml file.
+        """
         dist: setuptools.dist.Distribution = self.distribution
 
         # pyproject.toml schema:
@@ -87,7 +91,14 @@ class WritePyproject(setuptools.Command):
         if dependencies:
             pyproject["project"]["dependencies"] = dependencies
 
-        tomlkit.dump(pyproject, sys.stdout)
+        return pyproject
+
+    def run(self):
+        """
+        Write out the contents of a pyproject.toml file containing information
+        ingested from ``setup.py`` and/or ``setup.cfg``.
+        """
+        tomlkit.dump(self._generate(), sys.stdout)
 
 
 __all__ = ["WritePyproject"]

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -43,27 +43,105 @@ version = "0.0.1"
     check_result(result, pyproject_toml)
 
 
-# install_requires tests, we use made-up module names here.
+# This next test should be kept up to date as we add support for more fields.
 
 
-def test_install_requires(project) -> None:
+def test_everything(project) -> None:
     """
-    Test the install_requires is passed through if given.
+    Test all fields that the project supports.
     """
     setup_cfg = """\
 [metadata]
 name = test-project
 version = 0.0.1
+author = David Zaslavsky, Stuart Longland
+author_email = diazona@ellipsix.net, me@vk4msl.com
+description = A dummy project with a sophisticated setup.cfg file
+long_description = file:README.md
+url = https://example.com/test-project
+classifiers =
+        Development Status :: 1 - Planning
+        Environment :: Console
+        Intended Audience :: Developers
+        License :: OSI Approved :: MIT License
+        Operating System :: OS Independent
+        Programming Language :: Python
+        Programming Language :: Python :: 3
+        Programming Language :: Python :: 3 :: Only
+        Programming Language :: Python :: 3.6
+        Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.8
+        Programming Language :: Python :: 3.9
+        Programming Language :: Python :: 3.10
+        Programming Language :: Python :: 3.11
+        Programming Language :: Python :: 3.12
+        Topic :: Software Development :: Testing
+keywords = setuptools testing
+project_urls =
+        Homepage = https://example.com/test-project
+        Documentation = https://example.com/test-project/docs
 
 [options]
+packages = find:
+package_dir =
+        = src
+include_package_data = true
+python_requires = >= 3.6
 install_requires =
         dependency1
         dependency2>=1.23
         dependency3<4.56
+setup_requires =
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+
+[options.packages.find]
+where = src
+exclude =
+        build*
+        dist*
+        docs*
+        tests*
+        *.tests
+        *.tests.*
+        tools*
+
+[options.extras_require]
+testing =
+        # taken from jaraco/skeleton (we just need an arbitrary list of packages)
+        pytest >= 6
+        pytest-checkdocs >= 2.4
+        pytest-black >= 0.3.7; \
+            python_implementation != "PyPy"
+        pytest-cov; \
+            python_implementation != "PyPy"
+        pytest-mypy >= 0.9.1; \
+            python_implementation != "PyPy"
+        pytest-enabler >= 2.2
+        pytest-ruff; sys_platform != "cygwin"
+
+docs =
+        # taken from jaraco/skeleton (we just need an arbitrary list of packages)
+        sphinx >= 3.5
+        jaraco.packaging >= 9
+        rst.linker >= 1.9
+        furo
+        sphinx-lint
+
+[options.entry_points]
+test_project.dummy =
+        ep1 = test_project.ep1
+        ep2 = test_project.ep2
+"""
+    readme_md = """\
+# test-project
+
+Lorem ipsum and all that
 """
     pyproject_toml = """\
 [build-system]
-requires = ["setuptools"]
+requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -72,102 +150,7 @@ version = "0.0.1"
 dependencies = ["dependency1", "dependency2>=1.23", "dependency3<4.56"]
 """
     project.setup_cfg(setup_cfg)
-    project.setup_py()
-    result = project.run()
-    check_result(result, pyproject_toml)
-
-
-# setup_requires tests: we have to use real dependencies that actually are
-# installed, otherwise the tests will fail.
-
-
-def test_setup_requires(project) -> None:
-    """
-    Test setup_requires is passed through with 'setuptools' dependency.
-    """
-    setup_cfg = """\
-[metadata]
-name = test-project
-version = 0.0.1
-
-[options]
-setup_requires =
-        sphinx
-        pytest>=6
-        pytest-black<99.88.77
-"""
-    pyproject_toml = """\
-[build-system]
-requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "test-project"
-version = "0.0.1"
-"""
-    project.setup_cfg(setup_cfg)
-    project.setup_py()
-    result = project.run()
-    check_result(result, pyproject_toml)
-
-
-def test_setup_requires_setuptools(project) -> None:
-    """
-    Test that we don't duplicate 'setuptools' in build requirements
-    """
-    setup_cfg = """\
-[metadata]
-name = test-project
-version = 0.0.1
-
-[options]
-setup_requires =
-        setuptools
-        sphinx
-        pytest>=6
-        pytest-black<99.88.77
-"""
-    pyproject_toml = """\
-[build-system]
-requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "test-project"
-version = "0.0.1"
-"""
-    project.setup_cfg(setup_cfg)
-    project.setup_py()
-    result = project.run()
-    check_result(result, pyproject_toml)
-
-
-def test_setup_requires_setuptools_version(project) -> None:
-    """
-    Test we can handle a build system that requires a specific setuptools version.
-    """
-    setup_cfg = """\
-[metadata]
-name = test-project
-version = 0.0.1
-
-[options]
-setup_requires =
-        setuptools>=34.56
-        sphinx
-        pytest>=6
-        pytest-black<99.88.77
-"""
-    pyproject_toml = """\
-[build-system]
-requires = ["pytest-black<99.88.77", "pytest>=6", "setuptools>=34.56", "sphinx"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "test-project"
-version = "0.0.1"
-"""
-    project.setup_cfg(setup_cfg)
+    project.write("README.md", readme_md)
     project.setup_py()
     result = project.run()
     check_result(result, pyproject_toml)

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -1,3 +1,8 @@
+"""
+Tests of the entire system, all the way out to writing TOML content to stdout.
+These tests involve actually running the command `setup.py pyproject`.
+"""
+
 import tomlkit
 
 

--- a/tests/test_static_data.py
+++ b/tests/test_static_data.py
@@ -1,0 +1,165 @@
+"""
+Tests of the "simple cases", where the data in setup.cfg or setup.py is read
+in by setuptools, stored as-is, and added directly or with minor transformations
+into the pyproject data structure, rather than being parsed and used to
+configure some kind of dynamic functionality.
+"""
+
+
+def test_name_and_version(project) -> None:
+    """
+    Test we can generate a basic project skeleton.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+"""
+    pyproject = {
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "project": {
+            "name": "test-project",
+            "version": "0.0.1",
+        },
+    }
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    assert result == pyproject
+
+
+# install_requires tests, we use made-up module names here.
+
+
+def test_install_requires(project) -> None:
+    """
+    Test the install_requires is passed through if given.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+install_requires =
+        dependency1
+        dependency2>=1.23
+        dependency3<4.56
+"""
+    pyproject = {
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "project": {
+            "name": "test-project",
+            "version": "0.0.1",
+            "dependencies": ["dependency1", "dependency2>=1.23", "dependency3<4.56"],
+        },
+    }
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    assert result == pyproject
+
+
+# setup_requires tests: we have to use real dependencies that actually are
+# installed, otherwise the tests will fail.
+
+
+def test_setup_requires(project) -> None:
+    """
+    Test setup_requires is passed through with 'setuptools' dependency.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+setup_requires =
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+"""
+    pyproject = {
+        "build-system": {
+            "requires": ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "project": {
+            "name": "test-project",
+            "version": "0.0.1",
+        },
+    }
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    assert result == pyproject
+
+
+def test_setup_requires_setuptools(project) -> None:
+    """
+    Test that we don't duplicate 'setuptools' in build requirements
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+setup_requires =
+        setuptools
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+"""
+    pyproject = {
+        "build-system": {
+            "requires": ["pytest-black<99.88.77", "pytest>=6", "setuptools", "sphinx"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "project": {
+            "name": "test-project",
+            "version": "0.0.1",
+        },
+    }
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    assert result == pyproject
+
+
+def test_setup_requires_setuptools_version(project) -> None:
+    """
+    Test we can handle a build system that requires a specific setuptools version.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+
+[options]
+setup_requires =
+        setuptools>=34.56
+        sphinx
+        pytest>=6
+        pytest-black<99.88.77
+"""
+    pyproject = {
+        "build-system": {
+            "requires": ["pytest-black<99.88.77", "pytest>=6", "setuptools>=34.56", "sphinx"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "project": {
+            "name": "test-project",
+            "version": "0.0.1",
+        },
+    }
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    assert result == pyproject


### PR DESCRIPTION
In this PR I'm splitting out most of the functionality of the plugin's `run()` method into a new method, `_generate()`, which returns the data structure corresponding to the contents of the `pyproject.toml` file but without actually writing it out as TOML. I've also modified the test infrastructure to give access to the return value of this method directly, through the new `Project.generate()` wrapper, so we can run tests without going through an unnecessary (ish?) round of writing the structure to TOML and then reading it back in.

I also copied all the existing tests but changed them to use this new `generate()` method. This introduces a bunch of duplicate tests. I think we can safely get rid of many of the original tests and just keep a few to make sure the whole process works, but most of our testing from now on can probably be done by using `generate()`. As I create this PR I'm not yet sure which/how many of the original tests it makes sense to remove, but we'll figure that out. @sjlongland I'd appreciate your thoughts on this.