### PR TITLE
Switch to more precise type definitions

### DIFF
--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -1,18 +1,47 @@
-import datetime
 import setuptools
 import sys
 import tomlkit
 from pep508_parser import parser as pep508
-from typing import List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 # After we drop support for Python <3.10, we can import TypeAlias directly from typing
-from typing_extensions import TypeAlias
+from typing_extensions import Required, TypedDict
 
 
-TOMLPrimitive: TypeAlias = Union[bool, int, float, str, datetime.datetime, datetime.date, datetime.time]
-TOMLArray: TypeAlias = Sequence["TOMLValue"]
-TOMLTable: TypeAlias = Mapping[str, "TOMLValue"]
-TOMLValue: TypeAlias = Union[TOMLPrimitive, TOMLArray, TOMLTable]
+# PEP 518
+BuildSystem: Type = TypedDict("BuildSystem", {"requires": List[str], "build-backend": str}, total=True)
+
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+Contributor: Type = TypedDict("Contributor", {"name": str, "email": str}, total=False)
+LicenseFile: Type = TypedDict("LicenseFile", {"file": str})
+LicenseText: Type = TypedDict("LicenseText", {"text": str})
+ReadmeInfo: Type = TypedDict("ReadmeInfo", {"file": str, "content-type": str})
+
+Project: Type = TypedDict(
+    "Project",
+    {
+        "authors": List[Contributor],
+        "classifiers": List[str],
+        "dependencies": List[str],
+        "description": str,
+        "dynamic": List[str],
+        "entry-points": Dict[str, Dict[str, str]],
+        "gui-scripts": Dict[str, str],
+        "keywords": List[str],
+        "license": Union[LicenseFile, LicenseText],
+        "maintainers": List[Contributor],
+        "name": Required[str],
+        "optional-dependencies": Dict[str, List[str]],
+        "readme": Union[str, ReadmeInfo],
+        "requires-python": str,
+        "scripts": Dict[str, str],
+        "urls": Dict[str, str],
+        "version": str,
+    },
+    total=False,
+)
+
+Pyproject: Type = TypedDict("Pyproject", {"build-system": BuildSystem, "project": Project}, total=False)
 
 
 class WritePyproject(setuptools.Command):
@@ -41,7 +70,7 @@ class WritePyproject(setuptools.Command):
             # We will need it here
             setup_requirements.add("setuptools")
 
-        pyproject: TOMLTable = {
+        pyproject: Pyproject = {
             "build-system": {
                 "requires": sorted(setup_requirements),
                 "build-backend": "setuptools.build_meta",


### PR DESCRIPTION
This PR replaces the TOML types with a new type that precisely defines the contents of the `pyproject` data structure field-by-field, according to PEPs [518](https://peps.python.org/pep-0518/) and [621](https://peps.python.org/pep-0621/) and the [documentation on the PyPA website](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/).

This helps prevent two kinds of type checking errors. First and most obviously, the new type is mutable - it uses `List` and `Dict` directly instead of `Sequence` and `Mapping` - so the type checker won't complain about assignments being made to it as we build it up.

Second, and slightly more subtle, is the fact that the type checker didn't previously have information about the types of individual fields in the tables, so it would apply overly strict checks to assignments at the second level and below of the structure. For example, this affects the line

```python
pyproject["project"]["dependencies"] = dependencies
```

In the old code, the type checker as it checks this line doesn't know what type `pyproject["project"]` is, only that it's *some* type which can be a value in a TOML table. So it will try to check every possible type that `pyproject["project"]` that could be to verify that it supports the item assignment protocol (`__setitem__()`) with a string key and a `List[str]` value. But of course, out of all the types of values that can exist in a TOML table, only mappings support that protocol, not sequences or primitive values (boolean, number, string, time). The only way to solve that, other than by giving up on typing this structure entirely, is to give the type checker information about which types of value is supposed to be in each field. Hence the use of `TypedDict`.

And of course, this is going to make it easier to catch erroneous assignments to fields of the `pyproject` data structure in the future.

This should address the issues I was having getting type checking to work in #25. It's a logically independent change so I want to merge it separately first.