### PR TITLE
Add a pre-commit hook to verify Github Actions configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,8 @@ repos:
   rev: 22.6.0
   hooks:
   - id: black
+
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.6.25
+  hooks:
+  - id: actionlint-docker


### PR DESCRIPTION
I'm using the [actionlint](https://github.com/rhysd/actionlint)-docker pre-commit hook to verify the workflow files. We could use the plain old actionlint hook instead (non-Docker) but I had some trouble compiling it on my machine so I figured this would be easier. If anyone complains about the dependency on Docker then we can adjust it accordingly.

This is going to help catch problems that may occur as we update the CI configuration in upcoming commits.

---

I made this change as part of #23 but it's logically independent and I'm still having problems getting #23 to pass tests, so I figured this should be merged separately.