### PR TITLE
Rewrite the release workflow and refactor existing GHA workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Reusable workflow that builds documentation locally
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  # Environment variables to support color support (jaraco/skeleton#66):
+  # Request colored output from CLI tools supporting it. Different tools
+  # interpret the value differently. For some, just being set is sufficient.
+  # For others, it must be a non-zero integer. For yet others, being set
+  # to a non-empty value is sufficient. For tox, it must be one of
+  # <blank>, 0, 1, false, no, off, on, true, yes. The only enabling value
+  # in common is "1".
+  FORCE_COLOR: 1
+  # MyPy's color enforcement (must be a non-zero number)
+  MYPY_FORCE_COLOR: -42
+  # Recognized by the `py` package, dependency of `pytest` (must be "1")
+  PY_COLORS: 1
+  # Make tox-wrapped tools see color requests
+  TOX_TESTENV_PASSENV: >-
+    FORCE_COLOR
+    NO_COLOR
+    PY_COLORS
+
+  # Suppress noisy pip warnings
+  PIP_DISABLE_PIP_VERSION_CHECK: 'true'
+  PIP_NO_PYTHON_VERSION_WARNING: 'true'
+  PIP_NO_WARN_SCRIPT_LOCATION: 'true'
+
+  # Disable the spinner, noise in GHA; TODO(webknjaz): Fix this upstream
+  # Must be "1".
+  TOX_PARALLEL_NO_SPINNER: 1
+
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run
+        run: tox -e docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,26 +110,3 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
-
-  release:
-    permissions:
-      contents: write
-    needs:
-    - check
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - name: Install tox
-        run: |
-          python -m pip install tox
-      - name: Run
-        run: tox -e release
-        env:
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,44 +1,18 @@
-name: tests
+name: Pre-merge and post-merge tests
 
 on: [push, pull_request]
 
 permissions:
   contents: read
 
-env:
-  # Environment variables to support color support (jaraco/skeleton#66):
-  # Request colored output from CLI tools supporting it. Different tools
-  # interpret the value differently. For some, just being set is sufficient.
-  # For others, it must be a non-zero integer. For yet others, being set
-  # to a non-empty value is sufficient. For tox, it must be one of
-  # <blank>, 0, 1, false, no, off, on, true, yes. The only enabling value
-  # in common is "1".
-  FORCE_COLOR: 1
-  # MyPy's color enforcement (must be a non-zero number)
-  MYPY_FORCE_COLOR: -42
-  # Recognized by the `py` package, dependency of `pytest` (must be "1")
-  PY_COLORS: 1
-  # Make tox-wrapped tools see color requests
-  TOX_TESTENV_PASSENV: >-
-    FORCE_COLOR
-    MYPY_FORCE_COLOR
-    NO_COLOR
-    PY_COLORS
-    PYTEST_THEME
-    PYTEST_THEME_MODE
-
-  # Suppress noisy pip warnings
-  PIP_DISABLE_PIP_VERSION_CHECK: 'true'
-  PIP_NO_PYTHON_VERSION_WARNING: 'true'
-  PIP_NO_WARN_SCRIPT_LOCATION: 'true'
-
-  # Disable the spinner, noise in GHA; TODO(webknjaz): Fix this upstream
-  # Must be "1".
-  TOX_PARALLEL_NO_SPINNER: 1
-
-
 jobs:
   test:
+    name: Run tests
+    uses: ./.github/workflows/test.yml
+    # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
         python:
@@ -56,42 +30,17 @@ jobs:
           platform: ubuntu-latest
         - python: pypy3.9
           platform: ubuntu-latest
-    runs-on: ${{ matrix.platform }}
-    # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
-    if: >
-      github.event_name != 'pull_request'
-      || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    continue-on-error: ${{ matrix.python == '3.12' }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-          allow-prereleases: true
-      - name: Install tox
-        run: |
-          python -m pip install tox
-      - name: Run
-        run: tox
+    with:
+      python-version: ${{ matrix.python }}
+      platform: ${{ matrix.platform }}
 
   docs:
-    runs-on: ubuntu-latest
+    name: Build documentation
+    uses: ./.github/workflows/docs.yml
     # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
     if: >
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    env:
-      TOXENV: docs
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-      - name: Install tox
-        run: |
-          python -m pip install tox
-      - name: Run
-        run: tox
 
   check:  # This job does nothing and is only used for the branch protection
     # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Publish package to PyPI
+
+on:
+  release:
+    types:
+    - published
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run a full pre-release test suite
+    uses: ./.github/workflows/test.yml
+    strategy:
+      matrix:
+        python:
+        - "3.8"
+        - "3.11"
+        - "3.12"
+        platform:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+        include:
+        - python: "3.9"
+          platform: ubuntu-latest
+        - python: "3.10"
+          platform: ubuntu-latest
+        - python: pypy3.9
+          platform: ubuntu-latest
+    with:
+      python-version: ${{ matrix.python }}
+      platform: ${{ matrix.platform }}
+  docs:
+    name: Build the documentation locally
+    uses: ./.github/workflows/docs.yml
+  build:
+    name: Build distribution packages
+    runs-on: ubuntu-latest
+    needs:
+    - test
+    - docs
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install pypa/build
+      run: python -m pip install --user build
+    - name: Build packages
+      run: python -m build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+        if-no-files-found: error
+  publish-to-test-pypi:
+    name: Publish packages to Test PyPI
+    runs-on: ubuntu-latest
+    needs:
+    - test
+    - docs
+    - build
+    environment: test-pypi
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+    - name: Publish packages to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
+  publish-to-pypi:
+    name: Publish packages to PyPI
+    runs-on: ubuntu-latest
+    needs:
+    - test
+    - docs
+    - build
+    - publish-to-test-pypi
+    environment: pypi
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist/
+    - name: Publish packages to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        print-hash: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Reusable workflow that runs all tests
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        required: true
+      platform:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  # Environment variables to support color support (jaraco/skeleton#66):
+  # Request colored output from CLI tools supporting it. Different tools
+  # interpret the value differently. For some, just being set is sufficient.
+  # For others, it must be a non-zero integer. For yet others, being set
+  # to a non-empty value is sufficient. For tox, it must be one of
+  # <blank>, 0, 1, false, no, off, on, true, yes. The only enabling value
+  # in common is "1".
+  FORCE_COLOR: 1
+  # MyPy's color enforcement (must be a non-zero number)
+  MYPY_FORCE_COLOR: -42
+  # Recognized by the `py` package, dependency of `pytest` (must be "1")
+  PY_COLORS: 1
+  # Make tox-wrapped tools see color requests
+  TOX_TESTENV_PASSENV: >-
+    FORCE_COLOR
+    MYPY_FORCE_COLOR
+    NO_COLOR
+    PY_COLORS
+    PYTEST_THEME
+    PYTEST_THEME_MODE
+
+  # Suppress noisy pip warnings
+  PIP_DISABLE_PIP_VERSION_CHECK: 'true'
+  PIP_NO_PYTHON_VERSION_WARNING: 'true'
+  PIP_NO_WARN_SCRIPT_LOCATION: 'true'
+
+  # Disable the spinner, noise in GHA; TODO(webknjaz): Fix this upstream
+  # Must be "1".
+  TOX_PARALLEL_NO_SPINNER: 1
+
+
+jobs:
+  test:
+    runs-on: ${{ inputs.platform }}
+    continue-on-error: ${{ inputs.python-version == '3.12' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+          allow-prereleases: true
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -25,21 +25,3 @@ deps =
 passenv = *
 commands =
 	python -m jaraco.develop.finalize
-
-
-[testenv:release]
-skip_install = True
-deps =
-	build
-	twine>=3
-	jaraco.develop>=7.1
-passenv =
-	TWINE_PASSWORD
-	GITHUB_TOKEN
-setenv =
-	TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
-commands =
-	python -c "import shutil; shutil.rmtree('dist', ignore_errors=True)"
-	python -m build
-	python -m twine upload dist/*
-	python -m jaraco.develop.create-github-release


### PR DESCRIPTION
In this PR I've removed the old release workflow (including the release environment in `tox.ini`) and added a completely new Github Actions workflow for handling a release. As part of that, I refactored the existing workflow into multiple files, including reusable workflows `test.yml` and `docs.yml` which get called in multiple ways from the primary workflows.

# Release step sequencing

The process I implemented here works as follows:

1. We start by making a Github release ("Github release" refers to the announcement page on Github that we make using [this form](https://github.com/diazona/setuptools-pyproject-migration/releases/new)), with a corresponding tag, in the Github web interface (or by using the Github API)
2. The workflow automatically runs and tests the code from a checkout of the main Git branch
3. It also tests the documentation from a checkout of the main Git branch
4. It builds the package for distribution
5. After getting a maintainer's approval through the Github UI (or API), it publishes the package to Test PyPI
6. Then after getting approval again, it publishes to PyPI

I'm not sure if that's the best way to sequence the steps involved in making a release, though. (Note I'm using "release" by itself to mean a tagged and published version, in contrast with "Github release") For one thing, the tests are not run against the actual distributable package, so there's a slight chance that a checkout of the repo would pass tests while the same tests run against the installable wheel would fail. (This is very unlikely, but it could happen if the package uses a hard-coded relative file or something like that.) This sequencing also carries the risk that the package might fail tests *after* creating the tag, and then we're faced with having a tagged release that doesn't work and can't be posted to PyPI, which kind of forces us to skip a version number.

There are some alternative sequences we could consider, such as this:

1. We start by making a Github release, with a corresponding tag, in the Github web interface (or by using the Github API)
2. The workflow automatically runs and builds the package for distribution
3. It tests the code from the package (not from the checkout)
4. It tests the documentation from a checkout of the main branch (because the documentation source isn't included in the wheel)
5. With approval, it publishes the package to Test PyPI
6. Again with approval, it publishes to PyPI

This would take care of the risk that tests pass against the checked-out source code but fail against the installed package. But it turns out to be somewhat tricky to set up tox to run tests against the installed package (although doable with some hacky workarounds in our case, at least for now).

Or we could do this:

1. Manually trigger a workflow
2. The workflow tests the code from a checkout of the main Git branch
3. It also tests the documentation from the main Git branch
4. It creates the tag to be used for the release
5. It builds the package for distribution
6. With approval, it publishes the package to Test PyPI
7. With approval, it publishes to PyPI
8. The workflow prompts us to create the Github release, or perhaps creates a draft Github release which we can then fill in with release notes and publish

That would take care of the risk of the tests failing when we've already created a tag, but it still has the problem where what we're testing is not exactly the same as what gets installed. And it's also awkward to have the semi-manual step of creating the Github release at the end, which basically needs Github Actions to prompt us to create a release but wait for us to actually fill in the release description. It would be nice to have the release notes prepared in advance.

I think the ideal sequence would be this:

1. We manually draft the Github release including the release notes and the name of the tag to be created, but don't make it public yet
2. The workflow runs and checks out the code in a local view
3. It creates the tag in that local view but doesn't push it up to Github
4. It builds the package for distribution
5. It tests the code from the package
6. It tests the documentation in the local view
7. Now that tests have passed, it pushes the tag from the local view to the Github repo
8. With approval, it publishes to Test PyPI
9. Then it publishes to PyPI
10. Finally it marks the previously drafted Github release as public

But it's fairly complicated to make all those steps happen in exactly that order, as well as to arrange for tests to be run against the built package. I decided to leave that as a future goal, and for now just commit something that we can use to make a release so that we're not blocked in making this package available to the public.
