### PR TITLE
Configure pre-commit.ci to skip the actionlint-docker hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,8 @@ repos:
   rev: v1.6.25
   hooks:
   - id: actionlint-docker
+
+ci:
+  skip:
+  # pre-commit.ci doesn't have Docker available
+  - actionlint-docker


### PR DESCRIPTION
Apparently the runners that [pre-commit.ci](https://pre-commit.ci/) uses don't have Docker installed, so Docker-based hooks will fail on that platform. Accordingly I'm setting the `actionlint-docker` hook to be skipped.

Technically this allows people to bypass the linting of Github Actions configuration and introduce an invalid workflow, but I don't think we have to worry about that too much. If there are syntax errors in the workflow configuration, Github might catch them, and otherwise someone should notice sooner or later when running `pre-commit` locally.

We could also start using the [lite version of pre-commit.ci](https://pre-commit.ci/lite.html) which runs as a Github Action, and that would allow us to use Docker hooks, but I don't think that's really necessary at this point.