### PR TITLE
Add support for author and maintainer fields

### DIFF
--- a/tests/test_contributors.py
+++ b/tests/test_contributors.py
@@ -1,0 +1,251 @@
+"""
+Tests of author and maintainer metadata
+"""
+
+
+class TestAuthors:
+    def test_single_author(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+author = Monty Python
+author_email = python@python.example.com
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "authors": [
+                    {"name": "Monty Python", "email": "python@python.example.com"},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+    def test_only_name(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+author = Monty Python
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "authors": [
+                    {"name": "Monty Python", "email": ""},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+    def test_only_email(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+author_email = python@python.example.com
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "authors": [
+                    {"name": "", "email": "python@python.example.com"},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+    def test_multiple_authors(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+author = John Cleese, Terry Gilliam
+author_email = john@python.example.com, terry-the-second@python.example.com
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "authors": [
+                    {"name": "John Cleese", "email": "john@python.example.com"},
+                    {"name": "Terry Gilliam", "email": "terry-the-second@python.example.com"},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+
+class TestMaintainers:
+    def test_single_maintainer(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+maintainer = Monty Python
+maintainer_email = python@python.example.com
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "maintainers": [
+                    {"name": "Monty Python", "email": "python@python.example.com"},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+    def test_only_name(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+maintainer = Monty Python
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "maintainers": [
+                    {"name": "Monty Python", "email": ""},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+    def test_only_email(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+maintainer_email = python@python.example.com
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "maintainers": [
+                    {"name": "", "email": "python@python.example.com"},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+    def test_multiple_maintainers(self, project) -> None:
+        setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+maintainer = John Cleese, Terry Gilliam
+maintainer_email = john@python.example.com, terry-the-second@python.example.com
+"""
+        pyproject = {
+            "build-system": {
+                "requires": ["setuptools"],
+                "build-backend": "setuptools.build_meta",
+            },
+            "project": {
+                "name": "test-project",
+                "version": "0.0.1",
+                "maintainers": [
+                    {"name": "John Cleese", "email": "john@python.example.com"},
+                    {"name": "Terry Gilliam", "email": "terry-the-second@python.example.com"},
+                ],
+            },
+        }
+        project.setup_cfg(setup_cfg)
+        project.setup_py()
+        result = project.generate()
+        assert result == pyproject
+
+
+def test_authors_and_maintainers(project) -> None:
+    """
+    Test a situation where both the author and maintainer fields are set.
+    """
+
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+author = Terry Jones, Michael Palin
+author_email = terry-the-first@python.example.com, michael@python.example.com
+maintainer = Graham Chapman, John Cleese
+maintainer_email = graham@python.example.com, john@python.example.com
+"""
+    pyproject = {
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "project": {
+            "name": "test-project",
+            "version": "0.0.1",
+            "authors": [
+                {"name": "Terry Jones", "email": "terry-the-first@python.example.com"},
+                {"name": "Michael Palin", "email": "michael@python.example.com"},
+            ],
+            "maintainers": [
+                {"name": "Graham Chapman", "email": "graham@python.example.com"},
+                {"name": "John Cleese", "email": "john@python.example.com"},
+            ],
+        },
+    }
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    assert result == pyproject

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -56,6 +56,8 @@ name = test-project
 version = 0.0.1
 author = David Zaslavsky, Stuart Longland
 author_email = diazona@ellipsix.net, me@vk4msl.com
+maintainer = David Zaslavsky, Stuart Longland
+maintainer_email = diazona@ellipsix.net, me@vk4msl.com
 description = A dummy project with a sophisticated setup.cfg file
 long_description = file:README.md
 url = https://example.com/test-project
@@ -148,6 +150,22 @@ build-backend = "setuptools.build_meta"
 name = "test-project"
 version = "0.0.1"
 dependencies = ["dependency1", "dependency2>=1.23", "dependency3<4.56"]
+
+[[project.authors]]
+name = "David Zaslavsky"
+email = "diazona@ellipsix.net"
+
+[[project.authors]]
+name = "Stuart Longland"
+email = "me@vk4msl.com"
+
+[[project.maintainers]]
+name = "David Zaslavsky"
+email = "diazona@ellipsix.net"
+
+[[project.maintainers]]
+name = "Stuart Longland"
+email = "me@vk4msl.com"
 """
     project.setup_cfg(setup_cfg)
     project.write("README.md", readme_md)

--- a/tests/test_transform_contributors.py
+++ b/tests/test_transform_contributors.py
@@ -1,0 +1,178 @@
+"""
+Unit tests of WritePyproject._transform_contributors()
+"""
+
+import pytest
+
+from setuptools_pyproject_migration import Contributor, WritePyproject
+from typing import List, Optional
+
+
+@pytest.mark.parametrize(
+    ("name_string", "email_string"),
+    [
+        ("Monty Python", "python@python.example.com"),
+        ("Python", "python@example.com"),
+        ("", "python@python.example.com"),
+        ("Monty Python", ""),
+    ],
+    ids=["normal", "minimal", "empty-name", "empty-email"],
+)
+def test_valid_single_contributor(name_string: Optional[str], email_string: Optional[str]) -> None:
+    expected_result: List[Contributor] = [{"name": (name_string or ""), "email": (email_string or "")}]
+    assert WritePyproject._transform_contributors(name_string, email_string) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("names", "emails"),
+    [
+        # two contributors
+        (
+            ("Terry Jones", "Michael Palin"),
+            ("terry-the-first@python.example.com", "michael@python.example.com"),
+        ),
+        # six contributors
+        (
+            ("Terry Jones", "Michael Palin", "Graham Chapman", "John Cleese", "Eric Idle", "Terry Gilliam"),
+            (
+                "terry-the-first@python.example.com",
+                "michael@python.example.com",
+                "graham@python.example.com",
+                "john@python.example.com",
+                "eric@python.example.com",
+                "terry-the-second@python.example.com",
+            ),
+        ),
+    ],
+    ids=["two-contributors", "six-contributors"],
+)
+def test_multiple_contributors(names: List[str], emails: List[str]) -> None:
+    # Construct the test case
+    name_string = ", ".join(names)
+    email_string = ", ".join(emails)
+    # Construct the expected result
+    expected_result = [{"name": n, "email": e} for n, e in zip(names, emails)]
+    assert WritePyproject._transform_contributors(name_string, email_string) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name_string", "email_string", "expected_result"),
+    [
+        (
+            "Terry Jones, Michael Palin",
+            "terry-the-first@python.example.com",
+            [
+                {"name": "Terry Jones", "email": "terry-the-first@python.example.com"},
+                {"name": "Michael Palin", "email": ""},
+            ],
+        ),
+        (
+            "Terry Jones",
+            "terry-the-first@python.example.com, michael@python.example.com",
+            [
+                {"name": "Terry Jones", "email": "terry-the-first@python.example.com"},
+                {"name": "", "email": "michael@python.example.com"},
+            ],
+        ),
+        (
+            "Terry Jones, Michael Palin",
+            "",
+            [
+                {"name": "Terry Jones", "email": ""},
+                {"name": "Michael Palin", "email": ""},
+            ],
+        ),
+        (
+            "",
+            "terry-the-first@python.example.com, michael@python.example.com",
+            [
+                {"name": "", "email": "terry-the-first@python.example.com"},
+                {"name": "", "email": "michael@python.example.com"},
+            ],
+        ),
+    ],
+    ids=["fewer-emails", "fewer-names", "no-emails", "no-names"],
+)
+def test_mismatched_lengths(name_string: str, email_string: str, expected_result: List[Contributor]) -> None:
+    assert WritePyproject._transform_contributors(name_string, email_string) == expected_result
+
+
+def test_absent_name() -> None:
+    """
+    Test the behavior of WritePyproject._transform_contributors() if the name
+    string is ``None``
+    """
+
+    email_string = "python@python.example.com"
+    expected_result: List[Contributor] = [{"name": "", "email": email_string}]
+    assert WritePyproject._transform_contributors(None, email_string) == expected_result
+
+
+def test_absent_email() -> None:
+    """
+    Test the behavior of WritePyproject._transform_contributors() if the email
+    string is ``None``
+    """
+
+    name_string = "Monty Python"
+    expected_result: List[Contributor] = [{"name": name_string, "email": ""}]
+    assert WritePyproject._transform_contributors(name_string, None) == expected_result
+
+
+def test_absent_both() -> None:
+    """
+    Test the behavior of WritePyproject._transform_contributors() if both
+    parameters are ``None``
+    """
+
+    expected_result: List[Contributor] = []
+    assert WritePyproject._transform_contributors(None, None) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name_string", "email_string", "expected_result"),
+    [
+        ("Eric Idle,", "eric@python.example.com,", [{"name": "Eric Idle", "email": "eric@python.example.com"}]),
+        (",Eric Idle", ",eric@python.example.com", [{"name": "Eric Idle", "email": "eric@python.example.com"}]),
+        (",Eric Idle,", ",eric@python.example.com,", [{"name": "Eric Idle", "email": "eric@python.example.com"}]),
+        ("Eric Idle,,", "eric@python.example.com,,", [{"name": "Eric Idle", "email": "eric@python.example.com"}]),
+        (",,Eric Idle", ",,eric@python.example.com", [{"name": "Eric Idle", "email": "eric@python.example.com"}]),
+        (
+            "Eric Idle,,Terry Gilliam",
+            "eric@python.example.com,,terry-the-first@python.example.com",
+            [
+                {"name": "Eric Idle", "email": "eric@python.example.com"},
+                {"name": "Terry Gilliam", "email": "terry-the-first@python.example.com"},
+            ],
+        ),
+        (",", ",", []),
+        (",,", ",,", []),
+    ],
+    ids=[
+        "trailing-comma",
+        "leading-comma",
+        "trailing-and-leading-commas",
+        "trailing-double-comma",
+        "leading-double-comma",
+        "middle-double-comma",
+        "lone-comma",
+        "lone-double-comma",
+    ],
+)
+def test_empty_components(name_string: str, email_string: str, expected_result: List[Contributor]) -> None:
+    """
+    Test that WritePyproject._transform_contributors() properly handles name
+    or email strings with empty components - two consecutive commas, or a comma
+    at the start or end of the string
+    """
+    assert WritePyproject._transform_contributors(name_string, email_string) == expected_result
+
+
+def test_invalid_email() -> None:
+    """
+    Test how the function handles a syntactically invalid email address
+    """
+    name_string = "Monty Python"
+    email_string = "python@"
+    expected_result: List[Contributor] = [{"name": name_string, "email": email_string}]
+    assert WritePyproject._transform_contributors(name_string, email_string) == expected_result


### PR DESCRIPTION
This pull request adds support for the author and maintainer fields in the plugin, and adds a bunch of tests to verify that it's working properly.

I made some arbitrary (but sensible) choices about how to handle unusual cases, like names without email addresses or vice versa, or extra commas - basically it just substitutes in an empty string any time something would be missing. I don't know if that aligns with how other tools work, but if we need to change that behavior later, it'll be easy to do so.

Closes #28 