### PR TITLE
Split linting/static checks apart from pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,17 +42,9 @@ testing =
 	pytest >= 6
 	pytest-console-scripts >= 1.2
 	pytest-checkdocs >= 2.4
-	pytest-black >= 0.3.7; \
-		# workaround for jaraco/skeleton#22
-		python_implementation != "PyPy"
 	pytest-cov
-	pytest-mypy >= 0.9.1; \
-		# workaround for jaraco/skeleton#22
-		python_implementation != "PyPy"
 	pytest-enabler >= 2.2; \
 		python_version >= "3.8"
-	pytest-ruff; \
-		python_version >= "3.7"
 
 	# local
 	importlib-metadata; \

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,16 @@ usedevelop = True
 extras =
 	testing
 
+# There is very little advantage to using the pre_commit tox environment,
+# compared to running pre-commit directly, but we provide it in case you want to
+# use it. For example, if you don't want to install pre-commit locally.
+[testenv:pre_commit]
+deps =
+	pre-commit
+commands =
+	pre-commit run --all-files
+skip_install = True
+
 [testenv:docs]
 extras =
 	docs


### PR DESCRIPTION
Static checks are already run by pre-commit, which gets called from CI, so there is very little I had to do to split them out of pytest. I just removed the pytest plugins that enable those checks.

I added a tox environment to allow people to run the static checks through tox in case they don't want to install and run pre-commit directly for some reason.

Closes #39