### PR TITLE
Various improvements to the README file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,11 @@ repos:
   hooks:
   - id: actionlint-docker
 
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.35.0
+  hooks:
+  - id: markdownlint-fix
+
 ci:
   skip:
   # pre-commit.ci doesn't have Docker available

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# setuptools-pyproject-migration
+
 [![PyPI](https://img.shields.io/pypi/v/setuptools-pyproject-migration.svg)](https://pypi.org/project/setuptools-pyproject-migration)
 
 ![PyPI versions](https://img.shields.io/pypi/pyversions/setuptools-pyproject-migration.svg)
@@ -10,14 +12,12 @@
 
 [![skeleton](https://img.shields.io/badge/skeleton-2023-informational)](https://blog.jaraco.com/skeleton)
 
-# setuptools-pyproject-migration
-
 `pyproject.toml` represents the new era of Python packaging, but many old
 projects are still using `setuptools`. That's where this package comes in:
 just activate a virtual environment, install `setuptools-pyproject-migration`,
 then you can run
 
-```
+```console
 python setup.py pyproject
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![skeleton](https://img.shields.io/badge/skeleton-2023-informational)](https://blog.jaraco.com/skeleton)
 
+## Introduction
+
 `pyproject.toml` represents the new era of Python packaging, but many old
 projects are still using `setuptools`. That's where this package comes in:
 just activate a virtual environment, install `setuptools-pyproject-migration`,
@@ -18,6 +20,11 @@ python setup.py pyproject
 
 to print out a nicely formatted `pyproject.toml` file with all the same metadata
 that you had in `setup.py` or `setup.cfg`.
+
+Or at least, that's the goal. The project is currently a work in progress with
+only partial support for all the attributes that might exist in a setuptools
+configuration, so this won't yet work for anything complex. Feel free to file
+an issue to highlight anything that needs to be added!
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # setuptools-pyproject-migration
 
 [![PyPI](https://img.shields.io/pypi/v/setuptools-pyproject-migration.svg)](https://pypi.org/project/setuptools-pyproject-migration)
-
 ![PyPI versions](https://img.shields.io/pypi/pyversions/setuptools-pyproject-migration.svg)
-
 [![tests](https://github.com/diazona/setuptools-pyproject-migration/workflows/tests/badge.svg)](https://github.com/diazona/setuptools-pyproject-migration/actions?query=workflow%3A%22tests%22)
-
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
 [![skeleton](https://img.shields.io/badge/skeleton-2023-informational)](https://blog.jaraco.com/skeleton)
 
 `pyproject.toml` represents the new era of Python packaging, but many old

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ testing =
 	# upstream
 	pytest >= 6
 	pytest-console-scripts >= 1.2
-	pytest-checkdocs >= 2.4
 	pytest-cov
 	pytest-enabler >= 2.2; \
 		python_version >= "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = setuptools-pyproject-migration
 author = David Zaslavsky, Stuart Longland
 author_email = diazona@ellipsix.net, me@vk4msl.com
 description = Create a pyproject.toml file from setuptools configuration
-long_description = file:README.rst
+long_description = file:README.md
 url = https://github.com/diazona/setuptools-pyproject-migration
 classifiers =
 	Development Status :: 2 - Pre-Alpha


### PR DESCRIPTION
This PR makes various improvements related to the README file:

- Fix the filename used in `setup.cfg`
- Add a linter for Markdown
- Remove the unused `pytest-checkdocs` package
- Improve formatting and add a bit of text to the README