### PR TITLE
.coveragerc: Exclude tests and their fixtures.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
 	# leading `*/` for pytest-dev/pytest-cov#456
 	*/.tox/*
+	tests/*
 disable_warnings =
 	couldnt-parse
 


### PR DESCRIPTION
As per https://github.com/diazona/setuptools-pyproject-migration/discussions/51 this drops the test cases themselves from the test coverage.