### PR TITLE
Fix or ignore all warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,3 +27,9 @@ filterwarnings=
 	## end upstream
 
 	ignore:The distutils package is deprecated and slated for removal:DeprecationWarning
+
+	ignore:setuptools.installer (is|and fetch_build_eggs are) deprecated::setuptools
+	ignore:'encoding' argument not specified::setuptools
+	ignore:pkg_resources is deprecated as an API:DeprecationWarning
+	ignore:module 'sre_constants' is deprecated:DeprecationWarning:pkg_resources._vendor.pyparsing
+	ignore:.+ is shallow and may cause errors:UserWarning:setuptools_scm.git

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,3 +25,5 @@ filterwarnings=
 	ignore:'encoding' argument not specified::build.env
 
 	## end upstream
+
+	ignore:The distutils package is deprecated and slated for removal:DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ class Project:
             # ahead and let the write_text() call fail in that case
             warnings.warn("Overwriting existing file {}".format(file))
 
-        file.write_text(content)
+        file.write_text(content, encoding="utf-8")
 
     def setup_cfg(self, content: str) -> None:
         """


### PR DESCRIPTION
I fixed the source of one warning related to the code in this project, and ignored some others that are issued by setuptools/distutils code. I think ignoring is the right call there because the whole purpose of this project is to process legacy configuration so we are naturally going to use some deprecated features, but I wouldn't mind having that double-checked.