### PR TITLE
Support the description field

### DIFF
--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -201,6 +201,11 @@ class WritePyproject(setuptools.Command):
         if classifiers:
             pyproject["project"]["classifiers"] = classifiers
 
+        description: str = dist.get_description()
+        # "UNKNOWN" is used by setuptools<62.2 when the description in setup.cfg is empty or absent
+        if description and description != "UNKNOWN":
+            pyproject["project"]["description"] = description
+
         # NB: ensure a consistent alphabetical ordering of dependencies
         dependencies = sorted(set(dist.install_requires))
         if dependencies:

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -157,6 +157,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "test-project"
 version = "0.0.1"
+description = "A dummy project with a sophisticated setup.cfg file"
 dependencies = ["dependency1", "dependency2>=1.23", "dependency3<4.56"]
 classifiers = [
     "Development Status :: 1 - Planning",

--- a/tests/test_static_data.py
+++ b/tests/test_static_data.py
@@ -5,6 +5,9 @@ into the pyproject data structure, rather than being parsed and used to
 configure some kind of dynamic functionality.
 """
 
+from setuptools import Distribution
+from setuptools_pyproject_migration import WritePyproject
+
 
 def test_name_and_version(project) -> None:
     """
@@ -163,3 +166,37 @@ setup_requires =
     project.setup_py()
     result = project.generate()
     assert result == pyproject
+
+
+def test_description() -> None:
+    description = "Description of TestProject"
+
+    cmd = WritePyproject(
+        Distribution(
+            dict(
+                name="TestProject",
+                version="1.2.3",
+                description=description,
+            )
+        )
+    )
+    result = cmd._generate()
+
+    assert result["project"]["description"] == description
+
+
+def test_empty_description() -> None:
+    description = ""
+
+    cmd = WritePyproject(
+        Distribution(
+            dict(
+                name="TestProject",
+                version="1.2.3",
+                description=description,
+            )
+        )
+    )
+    result = cmd._generate()
+
+    assert "description" not in result["project"]


### PR DESCRIPTION
This PR adds support and a few tests for the `description` field. It's pretty straightforward.