### PR TITLE
Support readme files

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,98 @@
+"""
+Tests of the ``readme`` field in ``pyproject.toml``, which can be populated
+from setuptools' ``long_description`` field
+"""
+
+import pathlib
+import pytest
+
+
+parametrize_readme_type = pytest.mark.parametrize(
+    ("extension", "mime_type"),
+    [
+        ("txt", "text/plain"),
+        ("md", "text/markdown"),
+        ("rst", "text/x-rst"),
+    ],
+    ids=["text", "markdown", "rst"],
+)
+
+
+@parametrize_readme_type
+def test_string_with_content_type(project, extension: str, mime_type: str) -> None:
+    long_description = "This is a long description string"
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+long_description = {long_description}
+long_description_content_type = {mime_type}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    readme = result["project"]["readme"]
+    assert isinstance(readme, dict)
+    readme_path: pathlib.Path = pathlib.Path(readme["file"])
+    assert readme_path.suffix == f".{extension}"
+    assert readme_path.exists()
+    assert readme_path.read_text(encoding="utf-8").rstrip("\n") == long_description
+    assert readme["content-type"] == mime_type
+
+
+def test_string_without_content_type(project) -> None:
+    long_description = "This is a long description string"
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+long_description = {long_description}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    readme = result["project"]["readme"]
+    assert isinstance(readme, str)
+    readme_path: pathlib.Path = pathlib.Path(readme)
+    # Without a content type specified, there should be no extension given to the README file
+    assert not readme_path.suffix
+    assert readme_path.exists()
+    assert readme_path.read_text(encoding="utf-8").rstrip("\n") == long_description
+
+
+@parametrize_readme_type
+def test_file_with_content_type(project, extension: str, mime_type: str) -> None:
+    readme_filename = f"README.{extension}"
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+long_description = file:{readme_filename}
+long_description_content_type = {mime_type}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.write(readme_filename, "Dummy README\n")
+    project.setup_py()
+    result = project.generate()
+    assert result["project"]["readme"] == {"content-type": mime_type, "file": readme_filename}
+
+
+@parametrize_readme_type
+def test_file_without_content_type(project, extension: str, mime_type: str) -> None:
+    # mime_type is unused but we keep it to be able to use the same parametrization as other tests
+    readme_filename = f"README.{extension}"
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+long_description = file:{readme_filename}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.write(readme_filename, "Dummy README\n")
+    project.setup_py()
+    result = project.generate()
+    assert result["project"]["readme"] == readme_filename

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -60,6 +60,7 @@ maintainer = David Zaslavsky, Stuart Longland
 maintainer_email = diazona@ellipsix.net, me@vk4msl.com
 description = A dummy project with a sophisticated setup.cfg file
 long_description = file:README.md
+long_description_content_type = text/markdown
 url = https://example.com/test-project
 classifiers =
         Development Status :: 1 - Planning
@@ -193,6 +194,10 @@ email = "diazona@ellipsix.net"
 [[project.maintainers]]
 name = "Stuart Longland"
 email = "me@vk4msl.com"
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
 
 [project.scripts]
 cliep1 = "test_project.cliep1"


### PR DESCRIPTION
This pull request adds support for readme files, populated by what setuptools calls the long description. This one is a bit more complicated because the naive way to get the field value, `get_long_description()`, reads the content of the readme file if one is specified, but we need the actual filename to write into `pyproject.toml`, so I went a little deep into the `Distribution` metadata to find the raw value.

The other notable thing about this bit of code is that it will actually write the long description to a file if it was hard-coded in the setuptools parameters. This is the first case in which the plugin generates something other than the content of a `pyproject.toml` file.