### PR TITLE
Streamline the manual creation of Distribution objects with new fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import setuptools.dist
 import warnings
 from pytest_console_scripts import ScriptRunner
 from setuptools_pyproject_migration import Pyproject, WritePyproject
-from typing import Callable, Iterator, List, Optional, Union
+from typing import Iterator, List, Optional, Union
 
 try:
     from importlib.metadata import version as im_version
@@ -210,28 +210,46 @@ def in_empty_directory(
     # fmt: on
 
 
-def _make_write_pyproject(**kwargs) -> WritePyproject:
-    """
-    A convenience function to create a :py:class:`WritePyproject` instance
-    initialized from a :py:class:`setuptools.dist.Distribution` with
-    the given arguments.
-    """
-    return WritePyproject(setuptools.dist.Distribution(kwargs))
+class WritePyprojectFactory:
+    DEFAULT_NAME = "TestProject"
+    DEFAULT_VERSION = "1.2.3"
+
+    def __call__(self, **kwargs) -> WritePyproject:
+        """
+        Create a :py:class:`WritePyproject` instance initialized from
+        a :py:class:`setuptools.dist.Distribution` with the given arguments.
+        """
+
+        kwargs.setdefault("name", self.DEFAULT_NAME)
+        kwargs.setdefault("version", self.DEFAULT_VERSION)
+        return WritePyproject(setuptools.dist.Distribution(kwargs))
+
+
+_factory_instance: WritePyprojectFactory = WritePyprojectFactory()
 
 
 @pytest.fixture
-def make_write_pyproject(in_empty_directory: None) -> Callable[..., WritePyproject]:
+def make_write_pyproject(in_empty_directory: None) -> WritePyprojectFactory:
     """
-    Provide a convenience function to create a :py:class:`WritePyproject`
-    instance initialized from a :py:class:`setuptools.dist.Distribution` with
-    given arguments.
+    Simplify the process of writing tests using a manually instantiated
+    :py:class:`setuptools.dist.Distribution`.
 
-    This fixture also changes into an empty directory to ensure that the created
-    ``Distribution`` instance only takes its attributes from the keyword
-    arguments passed, not from any setuptools configuration files that may exist
-    in the current directory. If you do want a ``Distribution`` object to use
-    files in the current directory as a configuration source, use
-    the :py:func:`project` fixture instead.
+    This fixture returns a convenience function that will accept any keyword
+    arguments, pass them as a dictionary to ``Distribution()``, and then use
+    the created ``Distribution`` instance to create a :py:class:`WritePyproject`.
+    Since the keywords ``name`` and ``version`` are mandatory, they will be
+    filled in with default values if they are not present in the arguments.
+    The default values used are accessible as the ``default_name`` and
+    ``default_version`` attributes of the returned object, in case a test needs
+    to use them for comparison.
+
+    In addition, this fixture ensures that any test requesting it runs in
+    an empty directory, to ensure that the created ``Distribution`` instance
+    only takes its attributes from the keyword arguments passed, not from any
+    setuptools configuration files that may exist in the working directory.
+    If you do want a ``Distribution`` object to use files in the current
+    directory as a configuration source, use the :py:func:`project` fixture
+    instead.
     """
 
-    return _make_write_pyproject
+    return _factory_instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,11 @@ import packaging.version
 import pathlib
 import pytest
 import setuptools
+import setuptools.dist
 import warnings
 from pytest_console_scripts import ScriptRunner
 from setuptools_pyproject_migration import Pyproject, WritePyproject
-from typing import Optional, Union
+from typing import Callable, Iterator, List, Optional, Union
 
 try:
     from importlib.metadata import version as im_version
@@ -155,3 +156,82 @@ def project(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, script_runn
     """
     monkeypatch.chdir(tmp_path)
     return Project(tmp_path, script_runner)
+
+
+@pytest.fixture(scope="session")
+def _session_empty_directory(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    """
+    Create an empty temporary directory that persists throughout the entire
+    session.
+
+    The directory is returned as a :py:class:`pathlib.Path` which has had
+    its write permission removed. While it's technically possible for a caller
+    to restore write permission and put something in the directory... don't
+    do that.
+    """
+    empty_tmpdir: pathlib.Path = tmp_path_factory.mktemp("empty")
+    # Make the directory read-only to try to prevent accidental creation of files in it.
+    # 0o555 gives read and execute (but not write) access to user, group, and others.
+    empty_tmpdir.chmod(0o555)
+    return empty_tmpdir
+
+
+# This has to be a function-scoped fixture because it relies on monkeypatch
+@pytest.fixture
+def in_empty_directory(
+    _session_empty_directory: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> Iterator[None]:
+    """
+    Change into an empty directory for the duration of the test.
+
+    The empty directory used is one that persists for the entire session and
+    has been set read-only to try to prevent any files from being created in
+    it. Test code should not write anything into the directory.
+    """
+
+    assert "project" not in request.fixturenames, "in_empty_directory fixture conflicts with project fixture"
+
+    # Change into the session's empty directory
+    monkeypatch.chdir(_session_empty_directory)
+
+    # Wait for the test to run
+    yield
+
+    # Make sure that the directory is still empty
+
+    # This is inefficient if a large number of files do get written into
+    # the directory, but we really shouldn't need to optimize for that case
+    dir_contents: List[pathlib.Path] = list(_session_empty_directory.iterdir())
+    # fmt: off
+    assert not dir_contents, \
+        "Files were added to the session's empty directory: " + ", ".join(f.name for f in dir_contents)
+    # fmt: on
+
+
+def _make_write_pyproject(**kwargs) -> WritePyproject:
+    """
+    A convenience function to create a :py:class:`WritePyproject` instance
+    initialized from a :py:class:`setuptools.dist.Distribution` with
+    the given arguments.
+    """
+    return WritePyproject(setuptools.dist.Distribution(kwargs))
+
+
+@pytest.fixture
+def make_write_pyproject(in_empty_directory: None) -> Callable[..., WritePyproject]:
+    """
+    Provide a convenience function to create a :py:class:`WritePyproject`
+    instance initialized from a :py:class:`setuptools.dist.Distribution` with
+    given arguments.
+
+    This fixture also changes into an empty directory to ensure that the created
+    ``Distribution`` instance only takes its attributes from the keyword
+    arguments passed, not from any setuptools configuration files that may exist
+    in the current directory. If you do want a ``Distribution`` object to use
+    files in the current directory as a configuration source, use
+    the :py:func:`project` fixture instead.
+    """
+
+    return _make_write_pyproject

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -1,9 +1,7 @@
-from setuptools_pyproject_migration import WritePyproject
-from setuptools.dist import Distribution
 from typing import List
 
 
-def test_simple_classifiers() -> None:
+def test_simple_classifiers(make_write_pyproject) -> None:
     """
     Test a simple setuptools configuration with some classifiers.
     """
@@ -21,19 +19,17 @@ def test_simple_classifiers() -> None:
         "Topic :: System :: Archiving :: Packaging",
     ]
 
-    cmd = WritePyproject(Distribution(dict(name="TestProject", version="1.2.3", classifiers=classifiers)))
-
+    cmd = make_write_pyproject(classifiers=classifiers)
     result = cmd._generate()
     assert result["project"]["classifiers"] == classifiers
 
 
-def test_empty_classifiers_list() -> None:
+def test_empty_classifiers_list(make_write_pyproject) -> None:
     """
     Test handling of an empty list of classifiers.
     """
 
-    cmd = WritePyproject(Distribution(dict(name="TestProject", version="1.2.3", classifiers=[])))
-
+    cmd = make_write_pyproject(classifiers=[])
     result = cmd._generate()
     assert "classifiers" not in result["project"]
 

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -5,22 +5,12 @@ Testing the logic that extracts the entrypoint data:
     - miscellaneous entrypoints
 """
 
-from setuptools_pyproject_migration import WritePyproject
-from setuptools.dist import Distribution
 
-
-def test_generate_noentrypoints():
+def test_generate_noentrypoints(make_write_pyproject):
     """
     Test distribution with no entry points generates no entry points
     """
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-            )
-        )
-    )
+    cmd = make_write_pyproject()
     result = cmd._generate()
 
     assert "scripts" not in result["project"]
@@ -28,23 +18,17 @@ def test_generate_noentrypoints():
     assert "entry-points" not in result["project"]
 
 
-def test_generate_clionly():
+def test_generate_clionly(make_write_pyproject):
     """
     Test distribution with only CLI scripts generates only "scripts"
     """
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                entry_points=dict(
-                    console_scripts=[
-                        "spanish-inquisition=montypython.unexpected:spanishinquisition",
-                        "brian=montypython.naughtyboy:brian",
-                    ]
-                ),
-            )
-        )
+    cmd = make_write_pyproject(
+        entry_points=dict(
+            console_scripts=[
+                "spanish-inquisition=montypython.unexpected:spanishinquisition",
+                "brian=montypython.naughtyboy:brian",
+            ]
+        ),
     )
     result = cmd._generate()
 
@@ -57,23 +41,17 @@ def test_generate_clionly():
     }
 
 
-def test_generate_guionly():
+def test_generate_guionly(make_write_pyproject):
     """
     Test distribution with only GUI scripts generates only "gui-scripts"
     """
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                entry_points=dict(
-                    gui_scripts=[
-                        "dead-parrot=montypython.sketch:petshop",
-                        "shrubbery=montypython.holygrail:knightswhosayni",
-                    ]
-                ),
-            )
-        )
+    cmd = make_write_pyproject(
+        entry_points=dict(
+            gui_scripts=[
+                "dead-parrot=montypython.sketch:petshop",
+                "shrubbery=montypython.holygrail:knightswhosayni",
+            ]
+        ),
     )
     result = cmd._generate()
 
@@ -86,23 +64,17 @@ def test_generate_guionly():
     }
 
 
-def test_generate_misconly():
+def test_generate_misconly(make_write_pyproject):
     """
     Test distribution with only misc entry points generates only "entry-points"
     """
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                entry_points={
-                    "project.plugins": [
-                        "babysnatchers=montypython.somethingcompletelydifferent:babysnatchers",
-                        "eels=montypython.somethingcompletelydifferent:eels",
-                    ]
-                },
-            )
-        )
+    cmd = make_write_pyproject(
+        entry_points={
+            "project.plugins": [
+                "babysnatchers=montypython.somethingcompletelydifferent:babysnatchers",
+                "eels=montypython.somethingcompletelydifferent:eels",
+            ]
+        },
     )
     result = cmd._generate()
 
@@ -117,31 +89,25 @@ def test_generate_misconly():
     }
 
 
-def test_generate_all_entrypoints():
+def test_generate_all_entrypoints(make_write_pyproject):
     """
     Test distribution with all entry point types, generates all sections
     """
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                entry_points={
-                    "console_scripts": [
-                        "spanish-inquisition=montypython.unexpected:spanishinquisition",
-                        "brian=montypython.naughtyboy:brian",
-                    ],
-                    "gui_scripts": [
-                        "dead-parrot=montypython.sketch:petshop",
-                        "shrubbery=montypython.holygrail:knightswhosayni",
-                    ],
-                    "project.plugins": [
-                        "babysnatchers=montypython.somethingcompletelydifferent:babysnatchers",
-                        "eels=montypython.somethingcompletelydifferent:eels",
-                    ],
-                },
-            )
-        )
+    cmd = make_write_pyproject(
+        entry_points={
+            "console_scripts": [
+                "spanish-inquisition=montypython.unexpected:spanishinquisition",
+                "brian=montypython.naughtyboy:brian",
+            ],
+            "gui_scripts": [
+                "dead-parrot=montypython.sketch:petshop",
+                "shrubbery=montypython.holygrail:knightswhosayni",
+            ],
+            "project.plugins": [
+                "babysnatchers=montypython.somethingcompletelydifferent:babysnatchers",
+                "eels=montypython.somethingcompletelydifferent:eels",
+            ],
+        },
     )
     result = cmd._generate()
 

--- a/tests/test_static_data.py
+++ b/tests/test_static_data.py
@@ -7,8 +7,6 @@ configure some kind of dynamic functionality.
 
 import pytest
 
-from setuptools import Distribution
-from setuptools_pyproject_migration import WritePyproject
 from typing import List
 
 
@@ -171,37 +169,19 @@ setup_requires =
     assert result == pyproject
 
 
-def test_description() -> None:
+def test_description(make_write_pyproject) -> None:
     description = "Description of TestProject"
 
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                description=description,
-            )
-        )
-    )
+    cmd = make_write_pyproject(description=description)
     result = cmd._generate()
-
     assert result["project"]["description"] == description
 
 
-def test_empty_description() -> None:
+def test_empty_description(make_write_pyproject) -> None:
     description = ""
 
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                description=description,
-            )
-        )
-    )
+    cmd = make_write_pyproject(description=description)
     result = cmd._generate()
-
     assert "description" not in result["project"]
 
 
@@ -214,45 +194,19 @@ def test_empty_description() -> None:
     ],
     ids=["simple", "zero-length", "space"],
 )
-def test_keywords(keywords: List[str]) -> None:
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                keywords=keywords,
-            )
-        )
-    )
+def test_keywords(make_write_pyproject, keywords: List[str]) -> None:
+    cmd = make_write_pyproject(keywords=keywords)
     result = cmd._generate()
-
     assert result["project"]["keywords"] == keywords
 
 
-def test_no_keywords() -> None:
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-                keywords=[],
-            )
-        )
-    )
+def test_no_keywords(make_write_pyproject) -> None:
+    cmd = make_write_pyproject(keywords=[])
     result = cmd._generate()
-
     assert "keywords" not in result["project"]
 
 
-def test_keywords_not_given() -> None:
-    cmd = WritePyproject(
-        Distribution(
-            dict(
-                name="TestProject",
-                version="1.2.3",
-            )
-        )
-    )
+def test_keywords_not_given(make_write_pyproject) -> None:
+    cmd = make_write_pyproject()
     result = cmd._generate()
-
     assert "keywords" not in result["project"]


### PR DESCRIPTION
This PR adds a new fixture, `make_write_pyproject`, which takes keyword arguments and passes them to the `Distribution` constructor, using that `Distribution` to create a `WritePyproject` instance. The fixture also ensures that the tests run in an empty directory, to prevent the `setup.cfg` and `setup.py` files in the project root directory from interfering with the test.

This streamlines a common workflow in our tests and makes it easier to write new tests that don't need a `setup.cfg` or `setup.py` file.