### PR TITLE
Support URLs

### DIFF
--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -257,6 +257,10 @@ class WritePyproject(setuptools.Command):
         if classifiers:
             pyproject["project"]["classifiers"] = classifiers
 
+        urls: Dict[str, str] = dist.metadata.project_urls
+        if urls:
+            pyproject["project"]["urls"] = urls
+
         description: str = dist.get_description()
         # "UNKNOWN" is used by setuptools<62.2 when the description in setup.cfg is empty or absent
         if description and description != "UNKNOWN":

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -233,6 +233,10 @@ email = "me@vk4msl.com"
 file = "README.md"
 content-type = "text/markdown"
 
+[project.urls]
+Homepage = "https://example.com/test-project"
+Documentation = "https://example.com/test-project/docs"
+
 [project.scripts]
 cliep1 = "test_project.cliep1"
 cliep2 = "test_project.cliep2"

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,128 @@
+"""
+Tests of the various ways that the ``urls`` field of ``pyproject.toml`` can be
+populated.
+"""
+
+from typing import Dict
+
+
+def test_one_project_url(make_write_pyproject):
+    """
+    Test that ``project_urls`` with one URL is faithfully copied into
+    the generated pyproject data structure.
+    """
+
+    project_urls: Dict[str, str] = {
+        "Homepage": "https://python.example.com/romani-ite-domum",
+    }
+    cmd = make_write_pyproject(project_urls=project_urls)
+    result = cmd._generate()
+    assert result["project"]["urls"] == project_urls
+
+
+def test_several_project_urls(make_write_pyproject):
+    """
+    Test that ``project_urls`` with more than one URL is faithfully copied into
+    the generated pyproject data structure.
+    """
+
+    project_urls: Dict[str, str] = {
+        "Homepage": "https://python.example.com/romani-ite-domum",
+        "Parrot Tracker": "https://python.example.com/that-pet-shop",
+    }
+    cmd = make_write_pyproject(project_urls=project_urls)
+    result = cmd._generate()
+    assert result["project"]["urls"] == project_urls
+
+
+def test_main_url(make_write_pyproject):
+    """
+    Test that if a project has a single URL in the ``url`` field and no entry
+    for ``project_urls``, the pyproject data structure does not wind up having
+    any URLs.
+
+    .. note::
+        This behavior has a good chance of changing in the future. It's probably
+        more useful for the ``url`` field value to be added to ``project_urls``.
+    """
+
+    url: str = "https://python.example.com/castle-aarrgh"
+    cmd = make_write_pyproject(url=url)
+    result = cmd._generate()
+    assert "urls" not in result["project"]
+
+
+def test_download_url(make_write_pyproject):
+    """
+    Test that if a project has a single URL in the ``download_url`` field and no
+    entry for ``project_urls``, the pyproject data structure does not wind up
+    having any URLs.
+
+    .. note::
+        This behavior has a good chance of changing in the future. It's probably
+        more useful for the ``download_url`` field value to be added to
+        ``project_urls``.
+    """
+
+    download_url: str = "https://python.example.com/shrubbery"
+    cmd = make_write_pyproject(download_url=download_url)
+    result = cmd._generate()
+    assert "urls" not in result["project"]
+
+
+def test_main_and_download_urls(make_write_pyproject):
+    """
+    Test that if a project has a single URL in each of the ``url`` and
+    ``download_url`` fields, and no entry for ``project_urls``, the pyproject
+    data structure does not wind up having any URLs.
+
+    .. note::
+        This behavior has a good chance of changing in the future. It's probably
+        more useful for the ``url`` and ``download_url`` field values to be
+        added to ``project_urls``.
+    """
+
+    url: str = "https://python.example.com/castle-aarrgh"
+    download_url: str = "https://python.example.com/shrubbery"
+    cmd = make_write_pyproject(url=url, download_url=download_url)
+    result = cmd._generate()
+    assert "urls" not in result["project"]
+
+
+def test_main_and_download_and_project_urls(make_write_pyproject):
+    """
+    Test that if a project has a single URL in each of the ``url`` and
+    ``download_url`` fields, as well as some URLs in ``project_urls``,
+    the pyproject data structure contains only the URLs from ``project_urls``.
+
+    .. note::
+        This *could* change in the future. It's probably more useful for
+        the project to have a homepage and download URL in ``project_urls``
+        regardless of where they are provided, but trying to combine
+        other fields with ``project_urls`` could easily lead to conflicts,
+        so figuring out how best to handle this is left as a future task.
+    """
+
+    project_urls: Dict[str, str] = {
+        "Download": "https://python.example.com/the-spanish-inquisition",  # bet you didn't expect that
+        "Homepage": "https://python.example.com/romani-ite-domum",
+        "Main": "https://python.example.com/the-holy-grail",
+        "Project": "https://python.example.com/flying-circus",
+        "Source": "https://python.example.com/cheeseshop",
+    }
+    url: str = "https://python.example.com/castle-aarrgh"
+    download_url: str = "https://python.example.com/shrubbery"
+    cmd = make_write_pyproject(url=url, download_url=download_url, project_urls=project_urls)
+    result = cmd._generate()
+    assert result["project"]["urls"] == project_urls
+
+
+def test_empty_project_urls(make_write_pyproject):
+    """
+    Test that an empty list of project URLs, with no URLs given in other fields,
+    does not produce a ``urls`` field in the result.
+    """
+
+    cmd = make_write_pyproject(project_urls={})
+    result = cmd._generate()
+    assert "urls" not in result["project"]


### PR DESCRIPTION
This PR adds support for URLs.

In its current form, it only copies over setuptools' `project_urls` field into the `urls` field of the output dict, but I suspect it's better to do something with the `url` and `download_url` fields if they exist. So I want to hold off on merging this for a while, to give us some time to think about it.

Closes #35 