### PR TITLE
Add a badge reflecting the status of the documentation build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/setuptools-pyproject-migration.svg)](https://pypi.org/project/setuptools-pyproject-migration)
 ![PyPI versions](https://img.shields.io/pypi/pyversions/setuptools-pyproject-migration.svg)
 [![tests](https://github.com/diazona/setuptools-pyproject-migration/workflows/tests/badge.svg)](https://github.com/diazona/setuptools-pyproject-migration/actions?query=workflow%3A%22tests%22)
+[![documentation](https://readthedocs.org/projects/setuptools-pyproject-migration/badge/?version=latest)](https://setuptools-pyproject-migration.readthedocs.io/en/latest/?badge=latest)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![skeleton](https://img.shields.io/badge/skeleton-2023-informational)](https://blog.jaraco.com/skeleton)


### PR DESCRIPTION
I noticed that we don't have a simple indicator of whether the docs are building successfully on readthedocs or not. readthedocs imposes more stringent requirements than the "native" documentation build that we run in tox, so it's very possible that it could be failing even though our own documentation build is passing, and we need a way to be notified of that. This commit adds the badge from readthedocs which will fulfill that purpose.