### PR TITLE
Add a console script to run the pyproject command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,58 @@
 ## Introduction
 
 `pyproject.toml` represents the new era of Python packaging, but many old
-projects are still using `setuptools`. That's where this package comes in:
-just activate a virtual environment, install `setuptools-pyproject-migration`,
-then you can run
-
-```console
-python setup.py pyproject
-```
-
-to print out a nicely formatted `pyproject.toml` file with all the same metadata
-that you had in `setup.py` or `setup.cfg`.
+projects are still using `setuptools`. That's where this package comes in: just
+install it, run it, and it will print out a nicely formatted `pyproject.toml`
+file with the same metadata that you had in `setup.py` or `setup.cfg`.
 
 Or at least, that's the goal. The project is currently a work in progress with
 only partial support for all the attributes that might exist in a setuptools
 configuration, so this won't yet work for anything complex. Feel free to file
 an issue to highlight anything that needs to be added!
+
+## Installation and usage
+
+There are two different ways to install this project. You can use either or both
+depending on what you prefer.
+
+### Standalone application
+
+To install `setuptools-pyproject-migration` as an application, we recommend
+using [pipx](https://pypa.github.io/pipx/) (though of course you can also do
+this with `pip install --user` or in a virtual environment of your choice).
+First make sure you have pipx installed, then run
+
+```console
+pipx install setuptools-pyproject-migration
+```
+
+After that, in any directory that has a `setup.py` and/or `setup.cfg` file, you
+can run
+
+```console
+setup-to-pyproject
+```
+
+and it will print out the content of `pyproject.toml` as computed from your
+`setup.py` and/or `setup.cfg`. Running `setup-to-pyproject -h` will print
+a brief usage summary.
+
+### Virtual environment
+
+Or you can use `setuptools-pyproject-migration` in a virtual environment you use
+to develop your project. Activate your virtual environment and then run
+
+```console
+python -m pip install `setuptools-pyproject-migration
+```
+
+and then running
+
+```console
+python setup.py pyproject
+```
+
+will print out the content of your `pyproject.toml` file.
 
 ## History
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,5 +66,7 @@ docs =
 	# local
 
 [options.entry_points]
+console_scripts =
+	setup-to-pyproject = setuptools_pyproject_migration.cli:main
 distutils.commands =
 	pyproject = setuptools_pyproject_migration:WritePyproject

--- a/src/setuptools_pyproject_migration/cli.py
+++ b/src/setuptools_pyproject_migration/cli.py
@@ -1,0 +1,65 @@
+"""
+A simple command-line interface to the plugin.
+"""
+
+import argparse
+import os.path
+import sys
+
+
+def _parse_args() -> argparse.Namespace:
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="""
+Run the pyproject setuptools command. This effectively does the same thing as
+
+    python setup.py pyproject
+
+except that if setup.py doesn't exist, it will act as though there were a "stub"
+setup.py script with the following contents:
+
+    import setuptools
+    setuptools.setup()
+
+Effectively, this lets you use setuptools-pyproject-migration without having to
+install the plugin in your project's virtual environment, and without having to
+create a setup.py file if all you have is setup.cfg.
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """
+    Run the :py:class:`WritePyproject` setuptools command. This does the same
+    thing as ``python setup.py pyproject``, except that if ``setup.py`` doesn't
+    exist, it will act as though there were a "stub" ``setup.py`` script with
+    the following contents:
+
+    .. code-block:: python
+        :name: stub-setup-py
+
+        import setuptools
+        setuptools.setup()
+
+    Effectively, this lets you use ``setuptools-pyproject-migration`` without
+    having to install the plugin and without having to create a ``setup.py``
+    file if all you have is ``setup.cfg``.
+    """
+    _parse_args()
+
+    sys.argv = ["setup.py", "pyproject"]
+
+    setup_code: str
+    if os.path.exists("setup.py"):
+        with open("setup.py") as f:
+            setup_code = f.read()
+    else:
+        setup_code = "import setuptools\nsetuptools.setup()\n"
+    setup_bytecode = compile(setup_code, "setup.py", "exec", dont_inherit=True)
+    exec(setup_bytecode)
+
+
+# Allow running as `python -m setuptools_pyproject_migration.cli`
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,24 @@ setuptools.setup()
             # Python 3.6 we can discard this branch.
             return self.script_runner.run("setup.py", "pyproject", cwd=self.root)
 
+    def run_cli(self):
+        """
+        Run the console script ``setup-to-pyproject`` on the created project and
+        return the output.
+
+        In contrast to :py:meth:`run()`, if ``setup.py`` doesn't exist, it will
+        not be created, because the script is supposed to work without it. If
+        you want to test the script's behavior with a ``setup.py`` file, create
+        it "manually" with a call to :py:meth:`setup_py()`.
+        """
+        if _new_console_scripts:
+            return self.script_runner.run(["setup-to-pyproject"], cwd=self.root)
+        else:
+            # pytest-console-scripts<1.4, which requires Python 3.7+, didn't
+            # support passing arguments as a list. Once we drop support for
+            # Python 3.6 we can discard this branch.
+            return self.script_runner.run("setup-to-pyproject", cwd=self.root)
+
     def generate(self) -> Pyproject:
         """
         Run the equivalent of ``setup.py pyproject`` but return the generated


### PR DESCRIPTION
This is an idea I had today: add a console script that does the same thing as `setup.py pyproject`. This way people can install this project once with e.g. `pipx` or `pip install --user`, and then run `setup-to-pyproject` in any directory where they have a project to convert and it should just work. They won't have to install this in the same virtual environment that they use to develop.

I included a couple tests of the script, just to verify that it does the same thing as `setup.py pyproject`, and updated the `README` file accordingly.