### PR TITLE
Add more detail to documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,33 @@
+API
+===
+
+|project| is only intended for use as a `setuptools`_ plugin or a command-line
+executable, so it does not expose an API to be used as a Python library.
+
+* :ref:`genindex`
+* :ref:`modindex`
+
+``setuptools_pyproject_migration``
+----------------------------------
+
+There should generally be no need to use this API unless you're trying to invoke
+setuptools plugins in a custom way, in which case you're probably better off
+looking at the `setuptools`_ documentation.
+
+.. automodule:: setuptools_pyproject_migration
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+``setuptools_pyproject_migration.cli``
+--------------------------------------
+
+This API is only meant for use by this project's built-in console script. You
+can call it from Python at your own risk.
+
+.. automodule:: setuptools_pyproject_migration.cli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. _setuptools: https://setuptools.pypa.io/en/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "jaraco.packaging.sphinx",
 ]
 
@@ -42,3 +43,7 @@ intersphinx_mapping = {
 
 # Preserve authored syntax for defaults
 autodoc_preserve_defaults = True
+
+extensions.append("sphinx_copybutton")
+# Exclude line numbers, prompts, and output from copying
+copybutton_exclude = ".linenos, .gp, .go"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,25 +1,30 @@
-Welcome to |project| documentation!
-===================================
+|project|
+=========
 
 .. sidebar-links::
+   self
+   usage-cli
+   usage-setuptools
+   api
+   history
    :home:
    :pypi:
 
-.. toctree::
-   :maxdepth: 1
+|project| provides a simple way to convert your existing `setuptools`_ project
+configuration to `pyproject.toml`_.
 
-   history
+Installation and usage
+----------------------
 
+There are two different ways to install this project. You can use either or both
+depending on what you prefer.
 
-.. automodule:: setuptools_pyproject_migration
-    :members:
-    :undoc-members:
-    :show-inheritance:
+..
+    TODO replace this with a toctree but in a way that doesn't duplicate links
+    in the sidebar
 
+* :doc:`usage-cli`
+* :doc:`usage-setuptools`
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+.. _setuptools: https://setuptools.pypa.io/en/latest/
+.. _pyproject.toml: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
    usage-cli
    usage-setuptools
    api
+   motivation
    history
    :home:
    :pypi:

--- a/docs/motivation.rst
+++ b/docs/motivation.rst
@@ -1,0 +1,36 @@
+Why bother?
+===========
+
+You might be wondering, why use this package at all? Isn't ``setup.py`` or
+``setup.cfg`` good enough? And honestly... yes, it is. For now.
+
+To briefly summarize a very long story, `setuptools`_ (the code that handles
+``setup.py`` and ``setup.cfg`` is a very large, complex, and *old* piece of
+software, and while it's very useful in many cases, there are other cases where
+people *don't* want to use it. So the Python community has agreed on a set of
+standards to allow other projects to do what setuptools does, namely building
+a Python package into something that you can upload to `PyPI`_. One of those
+standards, the one that matters for us, is :pep:`621`, which defines how core
+project metadata (some of the information that people would normally put in
+``setup.cfg`` or as keyword arguments to ``setup()``) should be stored in a new
+standard file called ``pyproject.toml``. And now that that standard exists,
+setuptools is strongly `encouraging people to use it <https://github.com/pypa/setuptools/issues/1688>`_.
+
+This project was born in `a conversation on Mastodon`_ when we realized that as
+far as we know, there's no existing tool to generically convert setuptools
+configuration data to ``pyproject.toml``. There are some tools that work on
+``setup.cfg``:
+
+- `ini2toml`_
+- `pyproject-migrator`_
+
+but that doesn't help all the projects which pass keyword arguments to
+the ``setup()`` call in ``setup.py``. This project is our attempt to make
+the process of migrating from the "old way" ``setup.py`` to the "new way"
+``pyproject.toml`` as convenient as possible.
+
+.. _setuptools: https://setuptools.pypa.io/en/latest/
+.. _PyPI: https://pypi.org/
+.. _a conversation on Mastodon: https://mastodon.longlandclan.id.au/@stuartl/110518282805008552
+.. _ini2toml: https://ini2toml.readthedocs.io/en/latest/
+.. _pyproject-migrator: https://github.com/akx/pyproject-migrator

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -1,0 +1,26 @@
+Use as a standalone application
+===============================
+
+To install |project| as an application, we recommend using `pipx`_ (though of
+course you can also do this with ``pip install --user`` or in a virtual
+environment of your choice). First make sure you have pipx installed, then run
+
+.. highlight:: console
+
+.. code-block::
+
+    $ pipx install setuptools-pyproject-migration
+
+After that, in any directory that has a ``setup.py`` and/or ``setup.cfg`` file,
+you can run
+
+.. code-block::
+
+    $ setup-to-pyproject
+
+and it will print out the content of ``pyproject.toml`` as computed from your
+``setup.py`` and/or ``setup.cfg``.
+
+Running ``setup-to-pyproject --help`` will print a brief usage summary.
+
+.. _pipx: https://pypa.github.io/pipx/

--- a/docs/usage-setuptools.rst
+++ b/docs/usage-setuptools.rst
@@ -1,0 +1,24 @@
+Use as a setuptools plugin
+==========================
+
+You can install |project| in a virtual environment of your choice, perhaps one
+that you already use to develop your project, by activating the environment and
+running
+
+.. code-block::
+
+    $ python -m pip install setuptools-pyproject-migration
+
+Then, make sure you're in the directory with your ``setup.py`` and/or
+``setup.cfg`` files, and run
+
+.. code-block::
+
+    $ python setup.py pyproject
+
+That will print out the content of your ``pyproject.toml`` file as computed from
+your ``setup.py`` and/or ``setup.cfg``.
+
+This method of using the plugin requires you to have a ``setup.py`` file. If you
+only use ``setup.cfg``, consider using the :doc:`CLI application <usage-cli>`
+instead.

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ docs =
 	sphinx-lint
 
 	# local
+	sphinx-copybutton
 
 [options.entry_points]
 console_scripts =

--- a/src/setuptools_pyproject_migration/cli.py
+++ b/src/setuptools_pyproject_migration/cli.py
@@ -31,13 +31,13 @@ create a setup.py file if all you have is setup.cfg.
 
 def main() -> None:
     """
-    Run the :py:class:`WritePyproject` setuptools command. This does the same
-    thing as ``python setup.py pyproject``, except that if ``setup.py`` doesn't
-    exist, it will act as though there were a "stub" ``setup.py`` script with
-    the following contents:
+    Run the :py:class:`setuptools_pyproject_migration.WritePyproject` setuptools
+    command. This does the same thing as ``python setup.py pyproject``, except
+    that if ``setup.py`` doesn't exist, it will act as though there were
+    a "stub" ``setup.py`` script with the following contents:
 
     .. code-block:: python
-        :name: stub-setup-py
+        :name: setup.py
 
         import setuptools
         setuptools.setup()
@@ -45,6 +45,12 @@ def main() -> None:
     Effectively, this lets you use ``setuptools-pyproject-migration`` without
     having to install the plugin and without having to create a ``setup.py``
     file if all you have is ``setup.cfg``.
+
+    .. note::
+
+        This function changes ``sys.argv``. If you call this from Python, make
+        sure to restore the original argument list afterwards if your program
+        needs it.
     """
     _parse_args()
 


### PR DESCRIPTION
This PR expands the Sphinx documentation by adding the usage instructions from the README file and restructuring the doc pages to be a bit more useful.

As part of the change, I added the [`sphinx_copybutton` extension](https://sphinx-copybutton.readthedocs.io/en/latest/) to make the commands easy to copy. (I also noticed that sphinx-copybutton uses a very nice theme for its own documentation, which we might want to adopt as well.)

Closes #71 