### PR TITLE
Add WIP repo status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # setuptools-pyproject-migration
 
+<!-- markdownlint-disable MD013 -->
 [![PyPI](https://img.shields.io/pypi/v/setuptools-pyproject-migration.svg)](https://pypi.org/project/setuptools-pyproject-migration)
 ![PyPI versions](https://img.shields.io/pypi/pyversions/setuptools-pyproject-migration.svg)
 [![tests](https://github.com/diazona/setuptools-pyproject-migration/workflows/tests/badge.svg)](https://github.com/diazona/setuptools-pyproject-migration/actions?query=workflow%3A%22tests%22)
 [![documentation](https://readthedocs.org/projects/setuptools-pyproject-migration/badge/?version=latest)](https://setuptools-pyproject-migration.readthedocs.io/en/latest/?badge=latest)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![skeleton](https://img.shields.io/badge/skeleton-2023-informational)](https://blog.jaraco.com/skeleton)
+<!-- markdownlint-enable MD013 -->
 
 ## Introduction
 


### PR DESCRIPTION
This badge text comes from https://www.repostatus.org, and appears to be a fairly well-defined way to indicate the status of a project. It's similar to the "Development Status" trove classifiers, but is more visible and not specific to Python.

This is not super important but seems like a nice bit of added value.