### PR TITLE
Add license field support

### DIFF
--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -245,6 +245,11 @@ class WritePyproject(setuptools.Command):
             "version": dist.get_version(),  # TODO try to reverse-engineer dynamic version
         }
 
+        # In older setuptools releases, unspecified license text is replaced with "UNKNOWN"
+        license_text = dist.get_license()
+        if license_text and (license_text != "UNKNOWN"):
+            pyproject["project"]["license"] = {"text": license_text}
+
         authors: List[Contributor] = self._transform_contributors(dist.get_author(), dist.get_author_email())
         if authors:
             pyproject["project"]["authors"] = authors

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,0 +1,241 @@
+"""
+Tests of the ``license`` field in ``pyproject.toml``, which can be populated
+from setuptools' ``license`` field.
+"""
+
+import textwrap
+
+# setuptools *ONLY* supports bare license strings in the `license` field.  There exists a
+# `license_files` and a deprecated `license_file` field.  The latter simply raises a warning and the
+# content is prepended to `license_files`.  Neither populates the `license` property.
+# `license` and `license_files` are the subject of a PEP: https://peps.python.org/pep-0639/  If accepted, likely
+# `license` will be deprecated in favour of a `license-expression` (for SPDX descriptors).
+
+
+def test_license_setupcfg_expression_string(project) -> None:
+    license_string = "MIT"
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+license = {license_string}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    license_data = result["project"]["license"]
+    assert license_data == {"text": license_string}
+
+
+def test_license_setupcfg_fulltext_string(project) -> None:
+    license_string = """\
+Python License, Version 2
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+(“PSF”), and the Individual or Organization (“Licensee”) accessing and
+otherwise using this software (“Python”) in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python
+alone or in any derivative version, provided, however, that PSF’s
+License Agreement and PSF’s notice of copyright, i.e., “Copyright (c)
+2001, 2002, 2003, 2004, 2005, 2006 Python Software Foundation; All Rights
+Reserved” are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an “AS IS”
+basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee. This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+——————————————-
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com (“BeOpen”), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization (“Licensee”) accessing and otherwise using
+this software in source or binary form and its associated
+documentation (“the Software”).
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an “AS IS”
+basis. BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions. Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee. This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party. As an exception, the “BeOpen Python” logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+CNRI OPEN SOURCE LICENSE AGREEMENT (for Python 1.6b1)
+————————————————–
+
+IMPORTANT: PLEASE READ THE FOLLOWING AGREEMENT CAREFULLY.
+
+BY CLICKING ON “ACCEPT” WHERE INDICATED BELOW, OR BY COPYING,
+INSTALLING OR OTHERWISE USING PYTHON 1.6, beta 1 SOFTWARE, YOU ARE
+DEEMED TO HAVE AGREED TO THE TERMS AND CONDITIONS OF THIS LICENSE
+AGREEMENT.
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 (“CNRI”), and the Individual or Organization
+(“Licensee”) accessing and otherwise using Python 1.6, beta 1
+software in source or binary form and its associated documentation,
+as released at the www.python.org Internet site on August 4, 2000
+(“Python 1.6b1”).
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a non-exclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display
+publicly, prepare derivative works, distribute, and otherwise use
+Python 1.6b1 alone or in any derivative version, provided, however,
+that CNRIs License Agreement is retained in Python 1.6b1, alone or
+in any derivative version prepared by Licensee.
+
+Alternately, in lieu of CNRIs License Agreement, Licensee may
+substitute the following text (omitting the quotes): “Python 1.6,
+beta 1, is made available subject to the terms and conditions in
+CNRIs License Agreement. This Agreement may be located on the
+Internet using the following unique, persistent identifier (known
+as a handle): 1895.22/1011. This Agreement may also be obtained
+from a proxy server on the Internet using the
+URL:http://hdl.handle.net/1895.22/1011”.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6b1 or any part thereof, and wants to make
+the derivative work available to the public as provided herein,
+then Licensee hereby agrees to indicate in any such work the nature
+of the modifications made to Python 1.6b1.
+
+4. CNRI is making Python 1.6b1 available to Licensee on an “AS IS”
+basis. CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR
+FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6b1
+WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR
+LOSS AS A RESULT OF USING, MODIFYING OR DISTRIBUTING PYTHON 1.6b1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY
+THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of Virginia, excluding conflict of
+law provisions. Nothing in this License Agreement shall be deemed
+to create any relationship of agency, partnership, or joint venture
+between CNRI and Licensee. This License Agreement does not grant
+permission to use CNRI trademarks or trade name in a trademark
+sense to endorse or promote products or services of Licensee, or
+any third party.
+
+8. By clicking on the “ACCEPT” button where indicated, or by copying,
+installing or otherwise using Python 1.6b1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+ACCEPT
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+————————————————–
+
+Copyright (c) 1991 – 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands. All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+"""
+
+    license_firstline, license_rest = license_string.split("\n", 1)
+    license_string_indented = license_firstline + "\n" + textwrap.indent(license_rest, "    ")
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+license = {license_string_indented}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+    license_data = result["project"]["license"]
+
+    # NB: setup.cfg may strip trailing newlines and whitespace
+    assert license_data == {"text": license_string.rstrip()}

--- a/tests/test_license_files.py
+++ b/tests/test_license_files.py
@@ -1,0 +1,52 @@
+"""
+Skeleton tests for ``license_files`` from ``setup.cfg``.  This is a ``setuptools`` extension which is not yet ratified
+by the Python community.
+
+``license_files`` is the subject of `PEP-639 <https://peps.python.org/pep-0639/>`_.
+"""
+
+import pytest
+
+
+@pytest.mark.xfail
+def test_license_files_setupcfg_globs(project) -> None:
+    """
+    Test that file names that contain glob characters are added as globs.
+    """
+    license_files = ["LICENSE.*", "COPYING.*"]
+    license_files_lst = ", ".join(license_files)
+
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+license_files = {license_files_lst}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+
+    assert result["project"]["license_files"] == {"globs": license_files}
+
+
+@pytest.mark.xfail
+def test_license_files_setupcfg_files(project) -> None:
+    """
+    Test that concrete file names are added as paths.
+    """
+    license_files = ["LICENSE.md", "COPYING"]
+    license_files_lst = ", ".join(license_files)
+
+    setup_cfg = f"""\
+[metadata]
+name = test-project
+version = 0.0.1
+license_files = {license_files_lst}
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.setup_py()
+    result = project.generate()
+
+    assert result["project"]["license_files"] == {"paths": license_files}

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -91,6 +91,7 @@ author_email = diazona@ellipsix.net, me@vk4msl.com
 maintainer = David Zaslavsky, Stuart Longland
 maintainer_email = diazona@ellipsix.net, me@vk4msl.com
 description = A dummy project with a sophisticated setup.cfg file
+license = MIT or other license expression
 long_description = file:README.md
 long_description_content_type = text/markdown
 url = https://example.com/test-project
@@ -212,6 +213,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",
 ]
+
+[project.license]
+text = "MIT or other license expression"
 
 [project.optional-dependencies]
 testing = [


### PR DESCRIPTION
One gripe I have is that `tomlkit` makes a new section, rather than doing this as an inline table.

So instead of this:

```toml
license = { text = "My License" }
```

we get:

```toml
[project.license]
text = "My License"
```

The latter may work better visually for multi-line licenses (the field can store a full custom license agreement if none of the "standard" ones suit), and _should_ be equivalent in terms of TOML behaviour.

But it doesn't match the examples shown in Python packaging docs.

It's not obvious how I coax `tomlkit` to emit the other format.

Reading the TOML spec, the two formats are seemingly identical in terms of the data represented, so I'll leave it as-is for now.  Closes Issue #32.