### PR TITLE
Add tests of real distribution packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,15 @@
 name: Pre-merge and post-merge tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      run-slow:
+        description: "Whether to run slow tests (normally they are skipped)"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -46,6 +55,7 @@ jobs:
       python-version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}
       force-minimum-dependencies: ${{ matrix.force-minimum-dependencies }}
+      run-slow: ${{ inputs.run-slow || false }}
   docs:
     name: Build documentation
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
       python-version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}
       force-minimum-dependencies: ${{ matrix.force-minimum-dependencies }}
+      run-slow: true
   docs:
     name: Build the documentation locally
     uses: ./.github/workflows/docs.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ on:
         type: boolean
         required: false
         default: false
+      # Set this flag to run even the slow tests
+      run-slow:
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -68,4 +73,10 @@ jobs:
         # For simplicity, we limit forced minimum dependencies to direct
         # dependencies and build system dependencies, not extra dependencies
         # like pytest or sphinx.
-        run: tox -e py ${{ inputs.force-minimum-dependencies && '--force-dep setuptools==56 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4' || '' }}
+        #
+        # Note the -- used to separate tox options from pytest options.
+        run: >
+          tox -e py
+          ${{ inputs.force-minimum-dependencies && '--force-dep setuptools==56 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4' || '' }}
+          --
+          ${{ inputs.run-slow && '' || '-m "not slow"' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,9 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
+    - pyproject-metadata
     - setuptools
+    - types-requests
 
 - repo: https://github.com/psf/black
   rev: 23.9.1

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -16,3 +16,11 @@ that extends ``sys.path``.
     :members:
     :undoc-members:
     :show-inheritance:
+
+``test_support.distribution``
+-----------------------------
+
+.. automodule:: test_support.distribution
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -1,0 +1,18 @@
+API: Test Support
+=================
+
+* :ref:`genindex`
+* :ref:`modindex`
+
+``test_support``
+----------------
+
+This package includes helper code that is only used for testing |project|
+itself. The code is made available when testing by a
+`pytest configuration option <https://docs.pytest.org/en/latest/reference/reference.html#confval-pythonpath>`_
+that extends ``sys.path``.
+
+.. automodule:: test_support
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,10 @@
+import os.path
+import sys
+
+
+# Ensure that test_support package is importable
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), "test_support"))
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
    usage-cli
    usage-setuptools
    api
+   api-test
    motivation
    history
    :home:

--- a/pytest.ini
+++ b/pytest.ini
@@ -33,3 +33,4 @@ filterwarnings=
 	ignore:pkg_resources is deprecated as an API:DeprecationWarning
 	ignore:module 'sre_constants' is deprecated:DeprecationWarning:pkg_resources._vendor.pyparsing
 	ignore:.+ is shallow and may cause errors:UserWarning:setuptools_scm.git
+pythonpath=test_support

--- a/pytest.ini
+++ b/pytest.ini
@@ -34,3 +34,6 @@ filterwarnings=
 	ignore:module 'sre_constants' is deprecated:DeprecationWarning:pkg_resources._vendor.pyparsing
 	ignore:.+ is shallow and may cause errors:UserWarning:setuptools_scm.git
 pythonpath=test_support
+markers =
+	slow: tests that take a longer time to run
+	needs_network: tests that need to download data from the internet

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,10 @@ testing =
 	importlib-metadata; \
 		python_version < "3.8"
 	packaging
+	# no version of pyproject-metadata supports Python 3.6
+	pyproject-metadata; \
+		python_version >= "3.7"
+	requests
 	types-setuptools
 
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ where = src
 [options.extras_require]
 testing =
 	# upstream
-	pytest >= 6
+	pytest >= 7
 	pytest-console-scripts >= 1.2
 	pytest-cov
 	pytest-enabler >= 2.2; \

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -101,6 +101,12 @@ Project: Type = TypedDict(
 )
 
 Pyproject: Type = TypedDict("Pyproject", {"build-system": BuildSystem, "project": Project}, total=False)
+"""
+The type of the data structure stored in a ``pyproject.toml`` file. This only
+includes the build system and core metadata portions, i.e. the ``build-system``
+and ``project`` tables. The data structure may contain other entries that are
+not constrained by this type.
+"""
 
 
 class WritePyproject(setuptools.Command):

--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -1,5 +1,6 @@
 import distutils.core
 import distutils.dist
+import logging
 import packaging.version
 import pathlib
 import setuptools
@@ -21,6 +22,9 @@ except ModuleNotFoundError:
 _new_console_scripts = (
     packaging.version.Version(im_version("pytest-console-scripts")) >= packaging.version.Version("1.4.0")  # fmt: skip
 )
+
+
+_logger = logging.getLogger("setuptools_pyproject_migration:test_support:" + __name__)
 
 
 class Project:
@@ -79,6 +83,7 @@ class Project:
             # ahead and let the write_text() call fail in that case
             warnings.warn("Overwriting existing file {}".format(file))
 
+        _logger.debug("Writing to %s", file)
         file.write_text(content, encoding="utf-8")
 
     def setup_cfg(self, content: str) -> None:
@@ -115,6 +120,7 @@ setuptools.setup()
         """
         if not (self.root / "setup.py").exists():
             self.setup_py()
+        _logger.debug("Running python setup.py pyproject in %s", self.root)
         if _new_console_scripts:
             return self.script_runner.run(["setup.py", "pyproject"], cwd=self.root)
         else:
@@ -133,6 +139,7 @@ setuptools.setup()
         you want to test the script's behavior with a ``setup.py`` file, create
         it "manually" with a call to :py:meth:`setup_py()`.
         """
+        _logger.debug("Running setup-to-pyproject in %s", self.root)
         if _new_console_scripts:
             return self.script_runner.run(["setup-to-pyproject"], cwd=self.root)
         else:
@@ -153,6 +160,7 @@ setuptools.setup()
         # The project fixture should already have set the proper working directory
         assert pathlib.Path.cwd() == self.root
 
+        _logger.debug("Calling distutils.core.run_setup() in %s", self.root)
         distribution: distutils.dist.Distribution = distutils.core.run_setup(
             "setup.py",
             # This should be changed to "commandline" if we start pass meaningful

--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -1,0 +1,184 @@
+import distutils.core
+import distutils.dist
+import packaging.version
+import pathlib
+import setuptools
+import setuptools.dist
+import warnings
+from pytest_console_scripts import ScriptRunner
+from setuptools_pyproject_migration import Pyproject, WritePyproject
+from typing import Optional, Union
+
+try:
+    from importlib.metadata import version as im_version
+except ModuleNotFoundError:
+    # See https://github.com/python/mypy/issues/13914 for why we ignore the error here
+    from importlib_metadata import version as im_version  # type: ignore[no-redef]
+
+
+# Once we drop support for Python 3.6 we can probably remove this check since
+# pytest-console-scripts 1.4.0 supports Python 3.7
+_new_console_scripts = (
+    packaging.version.Version(im_version("pytest-console-scripts")) >= packaging.version.Version("1.4.0")  # fmt: skip
+)
+
+
+class Project:
+    """
+    A Python project on which ``setup.py pyproject`` can be run. Test code
+    should not normally construct instances of ``Project()`` directly;
+    instead, they can get one through a fixture or some helper function.
+
+    Once you have the ``Project`` object, create any files you need underneath
+    the root by calling :py:meth:`.write()` or one of its convenience wrappers
+    like :py:meth:`.setup_py()` or :py:meth:`.setup_cfg()`. If you need to do
+    anything other than creating files or if there is some reason not to use
+    the ``write()`` method, you can work directly on :py:attr:`.root`, but don't
+    change anything outside of ``root``. Finally, when all necessary files have
+    been created, call one of :py:meth:`.run()`, :py:meth:`.run_cli()`, or
+    :py:meth:`.generate()` to run ``setup.py pyproject`` (or an equivalent) on
+    the project.
+
+    :param root:
+        The root directory in which to create the project. It should already
+        exist. Typically this might be a temporary directory created by pytest's
+        ``tmp_path`` fixture.
+
+    :param script_runner:
+        The ``script_runner`` fixture from ``pytest-console-scripts``.
+    """
+
+    def __init__(self, root: pathlib.Path, script_runner: ScriptRunner) -> None:
+        self.root: pathlib.Path = root
+        self.script_runner: ScriptRunner = script_runner
+
+    def write(self, filename: Union[pathlib.Path, str], content: str) -> None:
+        """
+        Write a file with the given content and the given filename relative to
+        the project root. If the file already exists, it will be overwritten after
+        issuing a warning.
+
+        :param filename:
+            A filename or ``pathlib.Path`` representing the file to write. This should
+            be a relative path, which will be interpreted relative to the project root
+            directory. If the referenced file is not inside the project root, a warning
+            will be issued.
+
+        :param content:
+            Text content to write to the file.
+        """
+        file = (self.root / filename).resolve()
+        try:
+            file.relative_to(self.root)
+        except ValueError:
+            warnings.warn("Writing to path {} which is not under project root {}".format(file, self.root))
+        if file.exists() and not file.is_dir():
+            # This warning message is confusing if the file is a directory, so just go
+            # ahead and let the write_text() call fail in that case
+            warnings.warn("Overwriting existing file {}".format(file))
+
+        file.write_text(content, encoding="utf-8")
+
+    def setup_cfg(self, content: str) -> None:
+        """
+        Write a ``setup.cfg`` file in the project root directory.
+
+        :param content:
+            Text content to write to the file.
+        """
+        self.write("setup.cfg", content)
+
+    def setup_py(self, content: Optional[str] = None) -> None:
+        """
+        Write a ``setup.py`` file in the project root directory.
+
+        :param content:
+            Text content to write to the file.
+        """
+        if content is None:
+            content = """
+import setuptools
+
+setuptools.setup()
+"""
+        self.write("setup.py", content)
+
+    def run(self):
+        """
+        Run ``setup.py pyproject`` on the created project and return the output.
+
+        If the project doesn't already have a ``setup.py`` file, a simple one will be
+        automatically created by calling :py:meth:`setup_py()` with no arguments before
+        running it.
+        """
+        if not (self.root / "setup.py").exists():
+            self.setup_py()
+        if _new_console_scripts:
+            return self.script_runner.run(["setup.py", "pyproject"], cwd=self.root)
+        else:
+            # pytest-console-scripts<1.4, which requires Python 3.7+, didn't
+            # support passing arguments as a list. Once we drop support for
+            # Python 3.6 we can discard this branch.
+            return self.script_runner.run("setup.py", "pyproject", cwd=self.root)
+
+    def run_cli(self):
+        """
+        Run the console script ``setup-to-pyproject`` on the created project and
+        return the output.
+
+        In contrast to :py:meth:`run()`, if ``setup.py`` doesn't exist, it will
+        not be created, because the script is supposed to work without it. If
+        you want to test the script's behavior with a ``setup.py`` file, create
+        it "manually" with a call to :py:meth:`setup_py()`.
+        """
+        if _new_console_scripts:
+            return self.script_runner.run(["setup-to-pyproject"], cwd=self.root)
+        else:
+            # pytest-console-scripts<1.4, which requires Python 3.7+, didn't
+            # support passing arguments as a list. Once we drop support for
+            # Python 3.6 we can discard this branch.
+            return self.script_runner.run("setup-to-pyproject", cwd=self.root)
+
+    def generate(self) -> Pyproject:
+        """
+        Run the equivalent of ``setup.py pyproject`` but return the generated
+        data structure that would go into pyproject.toml instead of writing it
+        out.
+        """
+        if not (self.root / "setup.py").exists():
+            self.setup_py()
+
+        # The project fixture should already have set the proper working directory
+        assert pathlib.Path.cwd() == self.root
+
+        distribution: distutils.dist.Distribution = distutils.core.run_setup(
+            "setup.py",
+            # This should be changed to "commandline" if we start pass meaningful
+            # arguments to script_args.
+            stop_after="config",
+        )
+        # run_setup() claims to return a distutils.dist.Distribution, but in
+        # practice it seems to return a setuptools.dist.Distribution, which is
+        # what we need to pass to WritePyproject(). However, the type checker
+        # complains if we don't take some step (like this assertion) to verify
+        # that it is in fact a setuptools.dist.Distribution.
+        #
+        # If this assertion ever fails we will need to find some kind of workaround.
+        assert isinstance(distribution, setuptools.dist.Distribution)
+        command: WritePyproject = WritePyproject(distribution)
+        return command._generate()
+
+
+class WritePyprojectFactory:
+    DEFAULT_NAME = "TestProject"
+    DEFAULT_VERSION = "1.2.3"
+
+    def __call__(self, **kwargs) -> WritePyproject:
+        """
+        Create a :py:class:`WritePyproject` instance initialized from
+        a :py:class:`setuptools.dist.Distribution` with the given arguments.
+        """
+
+        kwargs.setdefault("name", self.DEFAULT_NAME)
+        kwargs.setdefault("version", self.DEFAULT_VERSION)
+        return WritePyproject(setuptools.dist.Distribution(kwargs))

--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -50,7 +50,9 @@ class Project:
 
     def __init__(self, root: pathlib.Path, script_runner: ScriptRunner) -> None:
         self.root: pathlib.Path = root
+        """The directory in which the project is to be created"""
         self.script_runner: ScriptRunner = script_runner
+        """The object from the ``script_runner`` fixture from ``pytest-console-scripts``"""
 
     def write(self, filename: Union[pathlib.Path, str], content: str) -> None:
         """

--- a/test_support/test_support/distribution.py
+++ b/test_support/test_support/distribution.py
@@ -1,0 +1,370 @@
+"""
+Support code for distribution package testing.
+
+"Distribution package" means the same thing here that it does in
+`importlib-metadata <https://importlib-metadata.readthedocs.io/en/latest/using.html>`_:
+basically a Python project that can be installed with ``pip`` or a compatible
+tool. Most distribution packages, of course, come from `PyPI <https://pypi.org/>`_,
+but it's also possible to use raw source code as a distribution package. Since
+this plugin only works on projects that use setuptools (and have not been
+converted to take setuptools configuration from ``pyproject.toml``), we only
+test with distribution packages that have ``setup.py`` or ``setup.cfg`` in their
+source code.
+"""
+
+import enum
+import hashlib
+import html.parser
+import logging
+import packaging
+import pathlib
+import re
+import requests
+import subprocess
+import tarfile
+import tempfile
+import urllib.parse
+import warnings
+
+from abc import ABC, abstractmethod
+from pytest_console_scripts import ScriptRunner
+from test_support import importlib_metadata, Project
+from typing import Any, List, Optional, Sequence
+
+try:
+    from pyproject_metadata import RFC822Message
+except ImportError:
+    # pyproject-metadata is not available for Python <3.7. That's okay because
+    # we skip all the tests that would use RFC822Message if pyproject-metadata
+    # is not available, so that name doesn't need to have a definition that is
+    # valid at runtime, but pytest still scans this file looking for doctests
+    # so it still needs to be importable. As long as this name is defined as
+    # _something_ which is a valid type, that will be the case.
+    class RFC822Message:  # type: ignore[no-redef]
+        pass
+
+
+_logger = logging.getLogger("setuptools_pyproject_migration:" + __name__)
+
+
+class HashChecker:
+    def __init__(self, algorithm: str, expected_hash: str):
+        self.algorithm: str = algorithm
+        self.expected_hash: str = expected_hash
+
+    @classmethod
+    def from_spec(cls, spec: str, sep: str = "="):
+        algorithm, _, hash = spec.partition(sep)
+        if not hash:
+            raise ValueError(f"Input {spec!r} is not a valid hash constraint")
+        return cls(algorithm, hash)
+
+    def check(self, data):
+        return hashlib.new(self.algorithm, data).hexdigest() == self.expected_hash
+
+
+class PackageType(enum.Enum):
+    SDIST = "sdist"
+    WHEEL = "bdist_wheel"
+
+
+class PackageInfo:
+    def __init__(self, package_url: str, package_hash_spec: str, metadata_hash_spec: Optional[str]):
+        self.package_type: PackageType
+        if package_url.endswith(".whl"):
+            self.package_type = PackageType.WHEEL
+        elif package_url.endswith(".tar.gz"):
+            self.package_type = PackageType.SDIST
+        else:
+            raise ValueError(f"Unrecognized extension for url {package_url!r}")
+        self.package_url: str = package_url
+        self.package_hasher: HashChecker = HashChecker.from_spec(package_hash_spec)
+        self.metadata_url: str = package_url + ".metadata"
+        self.metadata_hasher: Optional[HashChecker]
+        if metadata_hash_spec:
+            self.metadata_hasher = HashChecker.from_spec(metadata_hash_spec)
+        else:
+            self.metadata_hasher = None
+
+
+class SimplePackageListingParser(html.parser.HTMLParser):
+    """
+    A bare-bones parser for the list of versions of a given package offered by
+    the simple repository API. It will select releases of the given version of
+    the package.
+    """
+
+    _filename_regex = re.compile(
+        r"(?P<name>[\w.-]+)-(?P<version>{}).+\.(?:whl|tar\.gz)".format(packaging.version.VERSION_PATTERN),
+        flags=re.VERBOSE | re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _normalize_package_name(name: str):
+        """
+        Normalize a Python package name in the manner specified by :pep:`503`.
+        """
+        return re.sub(r"[-_.]+", "-", name).lower()
+
+    def __init__(self, name: str, version: str):
+        super().__init__()
+        self.normalized_name: str = self._normalize_package_name(name)
+        self.version: packaging.version.Version = packaging.version.parse(version)
+        self.releases: List[PackageInfo] = []
+
+    def handle_starttag(self, tag: Any, attrs: Any):
+        if not isinstance(tag, str):
+            raise TypeError(f"Tag {tag!r} is not a string")
+        if tag != "a":
+            return
+        href: Optional[str] = None
+        data_dist_info_metadata: Optional[str] = None
+        for k, v in attrs:
+            if not isinstance(k, str) or not isinstance(v, str):
+                raise TypeError(f"Unexpected type of HTML tag attribute {k!r}={v!r}")
+            if k == "href":
+                href = v
+            elif k == "data-dist-info-metadata":
+                data_dist_info_metadata = v
+        if not href:
+            return  # This <a> is not a link
+        parsed_url: urllib.parse.ParseResult = urllib.parse.urlparse(href)
+        filename: str
+        _, _, filename = parsed_url.path.rpartition("/")
+        m = self._filename_regex.match(filename)
+        if not m or self.version != packaging.version.parse(m.group("version")):
+            return
+        assert self.normalized_name == self._normalize_package_name(m.group("name"))
+        no_fragment_url: str = urllib.parse.urlunparse(list(parsed_url[:5]) + [""])
+        self.releases.append(PackageInfo(no_fragment_url, parsed_url.fragment, data_dist_info_metadata))
+
+
+class DistributionPackage(ABC):
+    """
+    A "distribution package" in the sense used in `importlib_metadata`_.
+
+    Basically, this is a Python project that can be installed with ``pip`` or
+    a compatible tool, and that has a ``setup.py`` or ``setup.cfg`` file.
+
+    .. _`importlib_metadata`: https://importlib-metadata.readthedocs.io/en/latest/using.html
+    """
+
+    def __init__(self) -> None:
+        self.test_id: Optional[str] = None
+
+    @abstractmethod
+    def prepare_source(self, path: pathlib.Path) -> pathlib.Path:
+        """
+        Populate a directory with the package's source code. This might involve
+        checking out a repository, extracting an archive, or something else,
+        depending on the type of project.
+
+        This method will be given an empty, writable directory. It should put
+        the distribution package's source code somewhere inside that directory
+        and return the path in which |project| should be run, i.e. the parent
+        directory of ``setup.py`` or ``setup.cfg`` (unless the distribution
+        package does something *extremely* weird that involves a custom path to
+        setuptools config files).
+
+        :param path: An empty, writable directory in which the package's source
+            code should be placed. Implementations can also use parts of this
+            directory as temporary storage; everything put in here will be
+            ignored except for the path returned.
+        :return: The root directory of the package, which contains ``setup.py``
+            or ``setup.cfg``. This may be ``path`` or a subdirectory of ``path``
+            depending on how the source code is prepared.
+        """
+
+    @abstractmethod
+    def core_metadata_reference(self) -> RFC822Message:
+        """
+        Return the "reference" core metadata for the distribution package.
+        Typically this comes from the package's wheel, if a wheel is available.
+
+        :return: The known correct core metadata for the distribution package
+        """
+
+
+class DistributionPackagePreparation:
+    """
+    A distribution package that has been prepared for testing. "Prepared" means
+    the source code is downloaded/extracted/checked out/whatever in a local
+    directory, in a state that allows |project| to run on it to generate
+    a ``pyproject.toml`` file.
+
+    .. note:
+        The "preparation" in the class name should be understood as the result
+        of preparing, not the _act_ of preparing. (Naming is hard)
+
+    :param distribution_package: The distribution package to prepare
+    :param path: The path in which to prepare the distribution package
+    :param script_runner: A runner that will be used to run |project|
+    """
+
+    # TODO get rid of the requirement to pass a ScriptRunner here
+    def __init__(self, distribution_package: DistributionPackage, path: pathlib.Path, script_runner: ScriptRunner):
+        self.distribution_package: DistributionPackage = distribution_package
+        self.path: pathlib.Path = path
+        project_root: pathlib.Path = distribution_package.prepare_source(path)
+        self.project: Project = Project(project_root, script_runner)
+
+
+class PyPiDistribution(DistributionPackage):
+    """
+    A distribution package obtained from PyPI.
+
+    :param name: The name of the project as registered on PyPI, i.e. the name
+         in the project's URL: ``https://pypi.org/project/<name>``
+    :param version: The version string of the project as registered on PyPI
+    :param project_root: The relative path within the project's sdist to
+        the directory containing ``setup.py`` or ``setup.cfg``. If omitted,
+        this defaults to ``<name>-<version>``, which matches the convention
+        used by most of the common build systems when preparing sdists.
+    """
+
+    def __init__(self, name: str, version: str, project_root: Optional[pathlib.Path] = None):
+        super().__init__()
+        self.name: str = name
+        self.version = version
+        self.basename: str = f"{self.name}-{self.version}"
+        self.package_spec: str = f"{self.name}=={self.version}"
+        self.test_id: Optional[str] = self.package_spec
+        self.project_root: pathlib.Path
+        if project_root:
+            if project_root.is_absolute():
+                raise ValueError(f"project_root must be a relative path, got {project_root!r}")
+            else:
+                self.project_root = project_root
+        else:
+            self.project_root = pathlib.Path(self.basename)
+
+    def prepare_source(self, path: pathlib.Path) -> pathlib.Path:
+        """
+        Populate a directory with the package's source code. This involves
+        downloading the sdist and extracting it.
+        """
+
+        # pip might not be the most efficient way to do this, since it seems
+        # to try building something - but pip does cache downloads
+        subprocess.check_call(["pip", "download", "--no-binary", ":all:", "--no-deps", self.package_spec])
+        _logger.debug("Extracting to %s", path)
+        with tarfile.open(self.basename + ".tar.gz") as tf:
+            tf.extractall(path=path, filter="data")
+        abs_project_root: pathlib.Path = path / self.project_root
+        _logger.debug("Project root: %s", abs_project_root)
+        if not (abs_project_root / "setup.py").exists() and not (abs_project_root / "setup.cfg").exists():
+            _logger.warning("No setup.py or setup.cfg in project root %s", abs_project_root)
+        return abs_project_root
+
+    def _parse_pypi_simple_listing(self) -> Sequence[PackageInfo]:
+        """
+        Access the PyPI simple API to download and parse the page that lists
+        versions for the package.
+
+        :return: A collection of :py:class:`PackageInfo` objects representing
+            all available releases of the right name and version. Typically this
+            will include one sdist and at least one wheel.
+        """
+
+        # Ideally we could use the pypi-simple package, but it doesn't support
+        # metadata downloads. (https://github.com/jwodder/pypi-simple/issues/6)
+        simple_api_response = requests.get(f"https://pypi.org/simple/{self.name}/")
+        simple_api_response.raise_for_status()
+        parser: SimplePackageListingParser = SimplePackageListingParser(self.name, self.version)
+        parser.feed(simple_api_response.text)
+        return parser.releases
+
+    def _get_metadata_from_pypi(self, wheel_release: PackageInfo) -> str:
+        """
+        Obtain the metadata for a package release from PyPI.
+
+        This will first try to download a separate metadata file as specified in
+        :pep:`658`. If that file exists, can be downloaded, and passes hash
+        verification (if a hash is available), then that's it. Otherwise, this
+        will download the actual wheel file and extract the metadata from it.
+
+        :param wheel_release: The wheel release for which to obtain metadata
+        :return: A string containing the metadata
+        :raises ValueError: If a separate metadata file was available and a hash
+            was provided for that file, and the file content did not match
+            the hash
+        """
+
+        assert wheel_release.package_type == PackageType.WHEEL
+        metadata_response = requests.get(wheel_release.metadata_url)
+        if metadata_response.status_code == requests.codes.ok:
+            if not wheel_release.metadata_hasher:
+                warnings.warn(f"No hash available for {self.name}=={self.version}")
+            elif not wheel_release.metadata_hasher.check(metadata_response.content):
+                raise ValueError(f"hash verification failed for {self.name}=={self.version}")
+            return metadata_response.text
+        elif metadata_response.status_code != requests.codes.not_found:
+            metadata_response.raise_for_status()
+
+        # No separate metadata file exists; this is fine, just download the wheel
+        wheel_response = requests.get(wheel_release.package_url)
+        with tempfile.NamedTemporaryFile(suffix=".whl") as tf:
+            # Write the data to a temporary wheel file and then read the metadata from it
+            # TODO it should be possible to do this completely in memory
+            for chunk in wheel_response.iter_content(chunk_size=4096):
+                tf.write(chunk)
+            tf.flush()
+            distribution = importlib_metadata.distributions(path=[tf.name])
+        return distribution["dist_info"]["metadata"]
+
+    @staticmethod
+    def _parse_metadata_from_text(metadata: str) -> RFC822Message:
+        """
+        Parse a text representation of package metadata into an :py:class:`RFC822Message`.
+
+        This is meant to do the same thing as :py:class:`email.parser.HeaderParser`
+        except that it produces an ``RFC822Message``.
+        """
+
+        message: RFC822Message = RFC822Message()
+        line: str
+        for line in metadata.splitlines():
+            line = line.rstrip("\r\n")
+            if not line:
+                # End of headers
+                break
+            key: str
+            value: Optional[str]
+            key, _, value = line.partition(":")
+            if not value:
+                raise ValueError(f"Could not parse metadata line {line!r}")
+            message[key] = value
+        return message
+
+    def core_metadata_reference(self) -> RFC822Message:
+        # We have several different ways to get metadata from the package:
+        # - Download wheel (or sdist) and install it, then use importlib_metadata to get the metadata:
+        #
+        #       distribution: importlib_metadata.Distribution = importlib_metadata.distribution(self.name)
+        #       expected_metadata: importlib_metadata.PackageMetadata = distribution.metadata
+        #       entry_points: importlib_metadata.EntryPoints = distribution.entry_points
+        #
+        # - Download sdist and extract it, then use the packaging system to emit the metadata
+        #
+        # - Download wheel and use wheel_inspect or importlib_metadata to get the metadata without
+        #   installing it
+        #
+        #        subprocess.check_call(
+        #            ["pip", "download", "--only-binary", ":all:", "--no-deps", "--dest", "dist",
+        #             f"{self.name}=={self.version}"]
+        #        )
+        #        etc.
+        #
+        # - Download metadata directly from PyPI, if it's available
+        #
+        # Theoretically all ways should give the same result; if not, we've got
+        # some more investigating to do.
+
+        releases: Sequence[PackageInfo] = self._parse_pypi_simple_listing()
+        try:
+            wheel_release: PackageInfo = next(r for r in releases if r.package_type == PackageType.WHEEL)
+        except StopIteration:
+            raise ValueError("No wheel found")
+        else:
+            metadata: str = self._get_metadata_from_pypi(wheel_release)
+            return self._parse_metadata_from_text(metadata)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,179 +1,23 @@
-import distutils.core
-import distutils.dist
-import packaging.version
 import pathlib
 import pytest
-import setuptools
-import setuptools.dist
-import warnings
+import test_support
 from pytest_console_scripts import ScriptRunner
-from setuptools_pyproject_migration import Pyproject, WritePyproject
-from typing import Iterator, List, Optional, Union
-
-try:
-    from importlib.metadata import version as im_version
-except ModuleNotFoundError:
-    # See https://github.com/python/mypy/issues/13914 for why we ignore the error here
-    from importlib_metadata import version as im_version  # type: ignore[no-redef]
-
-
-# Once we drop support for Python 3.6 we can probably remove this check since
-# pytest-console-scripts 1.4.0 supports Python 3.7
-_new_console_scripts = (
-    packaging.version.Version(im_version("pytest-console-scripts")) >= packaging.version.Version("1.4.0")  # fmt: skip
-)
-
-
-class Project:
-    """
-    A Python project on which ``setup.py pyproject`` can be run. Tests should get access
-    to instances of this class by requesting the :py:func:`project()` fixture.
-
-    Instantiating ``Project`` creates the project under the given root directory, which
-    will typically be provided by pytest's ``tmp_path`` fixture. After instantiating
-    the ``Project`` object, create files underneath the root by calling methods like
-    :py:meth:`.setup_py()` and :py:meth:`.setup_cfg()`, or :py:meth:`.write()` for
-    custom filenames. Any unusual cases can be handled by directly operating on
-    :py:attr:`.root`. Finally, call :py:meth:`.run()` to run ``setup.py pyproject`` on
-    the project.
-
-    :param root:
-        The root directory in which to create the project. It should already exist.
-
-    :param script_runner:
-        The ``script_runner`` fixture from ``pytest-console-scripts``.
-    """
-
-    def __init__(self, root: pathlib.Path, script_runner: ScriptRunner) -> None:
-        self.root: pathlib.Path = root
-        self.script_runner: ScriptRunner = script_runner
-
-    def write(self, filename: Union[pathlib.Path, str], content: str) -> None:
-        """
-        Write a file with the given content and the given filename relative to
-        the project root. If the file already exists, it will be overwritten after
-        issuing a warning.
-
-        :param filename:
-            A filename or ``pathlib.Path`` representing the file to write. This should
-            be a relative path, which will be interpreted relative to the project root
-            directory. If the referenced file is not inside the project root, a warning
-            will be issued.
-
-        :param content:
-            Text content to write to the file.
-        """
-        file = (self.root / filename).resolve()
-        try:
-            file.relative_to(self.root)
-        except ValueError:
-            warnings.warn("Writing to path {} which is not under project root {}".format(file, self.root))
-        if file.exists() and not file.is_dir():
-            # This warning message is confusing if the file is a directory, so just go
-            # ahead and let the write_text() call fail in that case
-            warnings.warn("Overwriting existing file {}".format(file))
-
-        file.write_text(content, encoding="utf-8")
-
-    def setup_cfg(self, content: str) -> None:
-        """
-        Write a ``setup.cfg`` file in the project root directory.
-
-        :param content:
-            Text content to write to the file.
-        """
-        self.write("setup.cfg", content)
-
-    def setup_py(self, content: Optional[str] = None) -> None:
-        """
-        Write a ``setup.py`` file in the project root directory.
-
-        :param content:
-            Text content to write to the file.
-        """
-        if content is None:
-            content = """
-import setuptools
-
-setuptools.setup()
-"""
-        self.write("setup.py", content)
-
-    def run(self):
-        """
-        Run ``setup.py pyproject`` on the created project and return the output.
-
-        If the project doesn't already have a ``setup.py`` file, a simple one will be
-        automatically created by calling :py:meth:`setup_py()` with no arguments before
-        running it.
-        """
-        if not (self.root / "setup.py").exists():
-            self.setup_py()
-        if _new_console_scripts:
-            return self.script_runner.run(["setup.py", "pyproject"], cwd=self.root)
-        else:
-            # pytest-console-scripts<1.4, which requires Python 3.7+, didn't
-            # support passing arguments as a list. Once we drop support for
-            # Python 3.6 we can discard this branch.
-            return self.script_runner.run("setup.py", "pyproject", cwd=self.root)
-
-    def run_cli(self):
-        """
-        Run the console script ``setup-to-pyproject`` on the created project and
-        return the output.
-
-        In contrast to :py:meth:`run()`, if ``setup.py`` doesn't exist, it will
-        not be created, because the script is supposed to work without it. If
-        you want to test the script's behavior with a ``setup.py`` file, create
-        it "manually" with a call to :py:meth:`setup_py()`.
-        """
-        if _new_console_scripts:
-            return self.script_runner.run(["setup-to-pyproject"], cwd=self.root)
-        else:
-            # pytest-console-scripts<1.4, which requires Python 3.7+, didn't
-            # support passing arguments as a list. Once we drop support for
-            # Python 3.6 we can discard this branch.
-            return self.script_runner.run("setup-to-pyproject", cwd=self.root)
-
-    def generate(self) -> Pyproject:
-        """
-        Run the equivalent of ``setup.py pyproject`` but return the generated
-        data structure that would go into pyproject.toml instead of writing it
-        out.
-        """
-        if not (self.root / "setup.py").exists():
-            self.setup_py()
-
-        # The project fixture should already have set the proper working directory
-        assert pathlib.Path.cwd() == self.root
-
-        distribution: distutils.dist.Distribution = distutils.core.run_setup(
-            "setup.py",
-            # This should be changed to "commandline" if we start pass meaningful
-            # arguments to script_args.
-            stop_after="config",
-        )
-        # run_setup() claims to return a distutils.dist.Distribution, but in
-        # practice it seems to return a setuptools.dist.Distribution, which is
-        # what we need to pass to WritePyproject(). However, the type checker
-        # complains if we don't take some step (like this assertion) to verify
-        # that it is in fact a setuptools.dist.Distribution.
-        #
-        # If this assertion ever fails we will need to find some kind of workaround.
-        assert isinstance(distribution, setuptools.dist.Distribution)
-        command: WritePyproject = WritePyproject(distribution)
-        return command._generate()
+from typing import Iterator, List
 
 
 @pytest.fixture
-def project(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, script_runner: ScriptRunner) -> Project:
+def project(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    script_runner: ScriptRunner,
+) -> test_support.Project:
     """
     Creates a temporary directory to serve as the root of a Python project. The returned
     object is an instance of :py:class:`Project`, and the directory can be populated
     with files before invoking ``setup.py pyproject`` with :py:meth:`Project.run()`.
     """
     monkeypatch.chdir(tmp_path)
-    return Project(tmp_path, script_runner)
+    return test_support.Project(tmp_path, script_runner)
 
 
 @pytest.fixture(scope="session")
@@ -228,26 +72,11 @@ def in_empty_directory(
     # fmt: on
 
 
-class WritePyprojectFactory:
-    DEFAULT_NAME = "TestProject"
-    DEFAULT_VERSION = "1.2.3"
-
-    def __call__(self, **kwargs) -> WritePyproject:
-        """
-        Create a :py:class:`WritePyproject` instance initialized from
-        a :py:class:`setuptools.dist.Distribution` with the given arguments.
-        """
-
-        kwargs.setdefault("name", self.DEFAULT_NAME)
-        kwargs.setdefault("version", self.DEFAULT_VERSION)
-        return WritePyproject(setuptools.dist.Distribution(kwargs))
-
-
-_factory_instance: WritePyprojectFactory = WritePyprojectFactory()
+_factory_instance: test_support.WritePyprojectFactory = test_support.WritePyprojectFactory()
 
 
 @pytest.fixture
-def make_write_pyproject(in_empty_directory: None) -> WritePyprojectFactory:
+def make_write_pyproject(in_empty_directory: None) -> test_support.WritePyprojectFactory:
     """
     Simplify the process of writing tests using a manually instantiated
     :py:class:`setuptools.dist.Distribution`.

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -1,0 +1,87 @@
+"""
+Tests of the plugin on real distribution packages.
+
+"Distribution package" in this sense means a full-fledged project that has
+source code and packaging metadata, as opposed to the mock projects created by
+our test suite. In short, these tests run the plugin on real Python projects to
+make sure it works. The tests run approximately the following procedure:
+
+1. Acquire the source code of an "external" project
+2. Build and package it in the standard way using a :pep:`517`-compliant
+   build frontend, like `build <https://github.com/pypa/build>`_
+3. Run ``python setup.py pyproject`` to convert the project's setuptools
+   configuration to a ``pyproject.toml``
+4. Build a wheel from that ``pyproject.toml``
+5. Compare the two wheels to make sure there are no differences that stem from
+   discrepancies in ``pyproject.toml``
+
+In practice, the implementation takes some shortcuts to avoid _actually_
+having to build all those wheel files, such as using already-published wheels
+from PyPI. But verifying that the procedure above works is the ultimate goal.
+"""
+
+import pathlib
+import pytest
+
+from pytest_console_scripts import ScriptRunner
+from typing import List
+
+# Try importing pyproject_metadata but don't save the module itself because we don't need it
+pytest.importorskip("pyproject_metadata")
+
+from pyproject_metadata import RFC822Message, StandardMetadata  # noqa: E402
+
+# If pyproject_metadata isn't available, test_support.distribution won't be either
+from test_support.distribution import (  # noqa: E402
+    DistributionPackage,
+    DistributionPackagePreparation,
+    PyPiDistribution,
+)
+
+
+# The return type here is _pytest.mark.structures.ParameterSet but that's not
+# part of pytest's public API so we don't use it.
+# See https://github.com/pytest-dev/pytest/issues/7469
+def _xfail(*args):
+    """
+    Syntactic sugar for marking a test as an expected failure.
+    """
+    return pytest.param(*args, marks=pytest.mark.xfail)
+
+
+distributions: List = [
+    # e.g.
+    # GitHubDistribution(url, commit-ish)
+    # PyPiDistribution(name, version)
+    _xfail(PyPiDistribution("pytest", "7.3.0")),
+    _xfail(PyPiDistribution("pytest-localserver", "0.8.0")),
+]
+
+
+@pytest.fixture(params=distributions, ids=lambda ep: ep.test_id)
+def distribution_package(
+    request: pytest.FixtureRequest, tmp_path: pathlib.Path, script_runner: ScriptRunner
+) -> DistributionPackagePreparation:
+    """
+    Prepare a DistributionPackage for testing. This populates the temporary
+    path with the package's source code.
+    """
+
+    dist: DistributionPackage = request.param
+    return DistributionPackagePreparation(dist, tmp_path, script_runner)
+
+
+@pytest.mark.needs_network
+@pytest.mark.slow
+def test_external_project(distribution_package: DistributionPackagePreparation, monkeypatch: pytest.MonkeyPatch):
+    """
+    Test that the generated core metadata for a distributable package
+    matches the pyproject.toml file we generate for that package.
+    """
+    monkeypatch.chdir(distribution_package.project.root)
+    expected_metadata: RFC822Message = distribution_package.distribution_package.core_metadata_reference()
+    actual_metadata: RFC822Message = StandardMetadata.from_pyproject(
+        distribution_package.project.generate()
+    ).as_rfc822()
+
+    assert str(expected_metadata) == str(actual_metadata)

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ extras =
 	testing
 changedir = docs
 commands =
-	python -m sphinx -W --keep-going . {toxinidir}/build/html
+	python -m sphinx --keep-going . {toxinidir}/build/html
 	python -m sphinxlint
 
 [testenv:finalize]


### PR DESCRIPTION
I've been working on this for the past few weeks: a framework that makes it easy to run the plugin on real packages from PyPI or a Git repo, and checks that the core metadata produced is correct.

Still WIP for now but I'm uploading as a checkpoint.