### PR TITLE
Remove setuptools maximum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-# TODO: remove "setuptools<=60.10.0" restriction once https://github.com/pypa/setuptools/issues/3744 is resolved
-requires = ["setuptools>=56", "setuptools<=60.10.0; python_version < '3.12'", "setuptools_scm[toml]>=3.4.1"]
+requires = ["setuptools>=56", "setuptools", "setuptools_scm[toml]>=3.4.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
On a whim I tried removing the setuptools version restriction from #60 and apparently it just works now....

I have no idea what made the difference. Maybe there was a relevant fix in a recent version of setuptools or something (current is 68.2.0). Regardless, I decided not to delay this PR while I spend time testing different dependency versions to narrow down the error, because this is one of the few things blocking our initial release. If we ever figure it out, we can add dependency constraints as needed to prevent other people from running into it.

Closes #61 