### PR TITLE
Update development status to alpha

### DIFF
--- a/changelog.d/9.doc
+++ b/changelog.d/9.doc
@@ -1,0 +1,1 @@
+Update development status to alpha

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ project_urls =
 	Source = https://github.com/diazona/setuptools-pyproject-migration
 	Issues = https://github.com/diazona/setuptools-pyproject-migration/issues
 classifiers =
-	Development Status :: 2 - Pre-Alpha
+	Development Status :: 3 - Alpha
 	Environment :: Plugins
 	Framework :: Setuptools Plugin
 	Intended Audience :: Developers


### PR DESCRIPTION
According to [this blog post](https://martin-thoma.com/software-development-stages/) which seems to have a sensible definition of development status classifiers, alpha software should have the minimal required set of features to be useful and the architecture is clear. I believe we've basically reached that level. Accordingly, I'm updating the status.

This should be merged right before we're ready to make an initial release.