### PR TITLE
Limit dependency on script runner fixture

### DIFF
--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -88,17 +88,11 @@ class Project:
         The root directory in which to create the project. It should already
         exist. Typically this might be a temporary directory created by pytest's
         ``tmp_path`` fixture.
-
-    :param runner:
-        A callable that can run a command with given arguments and return
-        a :py:class:`ProjectRunResult`.
     """
 
-    def __init__(self, root: pathlib.Path, runner: ProjectRunner) -> None:
+    def __init__(self, root: pathlib.Path) -> None:
         self.root: pathlib.Path = root
         """The directory in which the project is to be created"""
-        self._runner: ProjectRunner = runner
-        """The function to call to actually run a script"""
 
     def write(self, filename: Union[pathlib.Path, str], content: str) -> None:
         """
@@ -152,20 +146,22 @@ setuptools.setup()
 """
         self.write("setup.py", content)
 
-    def run(self) -> ProjectRunResult:
+    def run(self, runner: ProjectRunner) -> ProjectRunResult:
         """
         Run ``setup.py pyproject`` on the created project and return the output.
 
         If the project doesn't already have a ``setup.py`` file, a simple one will be
         automatically created by calling :py:meth:`setup_py()` with no arguments before
         running it.
+
+        :param runner: The callable to use to run the script
         """
         if not (self.root / "setup.py").exists():
             self.setup_py()
         _logger.debug("Running python setup.py pyproject in %s", self.root)
-        return self._runner(["setup.py", "pyproject"], cwd=self.root)
+        return runner(["setup.py", "pyproject"], cwd=self.root)
 
-    def run_cli(self) -> ProjectRunResult:
+    def run_cli(self, runner: ProjectRunner) -> ProjectRunResult:
         """
         Run the console script ``setup-to-pyproject`` on the created project and
         return the output.
@@ -174,9 +170,11 @@ setuptools.setup()
         not be created, because the script is supposed to work without it. If
         you want to test the script's behavior with a ``setup.py`` file, create
         it "manually" with a call to :py:meth:`setup_py()`.
+
+        :param runner: The callable to use to run the script
         """
         _logger.debug("Running setup-to-pyproject in %s", self.root)
-        return self._runner(["setup-to-pyproject"], cwd=self.root)
+        return runner(["setup-to-pyproject"], cwd=self.root)
 
     def generate(self) -> Pyproject:
         """

--- a/test_support/test_support/distribution.py
+++ b/test_support/test_support/distribution.py
@@ -27,7 +27,6 @@ import urllib.parse
 import warnings
 
 from abc import ABC, abstractmethod
-from pytest_console_scripts import ScriptRunner
 from test_support import importlib_metadata, Project
 from typing import Any, List, Optional, Sequence
 
@@ -202,11 +201,11 @@ class DistributionPackagePreparation:
     """
 
     # TODO get rid of the requirement to pass a ScriptRunner here
-    def __init__(self, distribution_package: DistributionPackage, path: pathlib.Path, script_runner: ScriptRunner):
+    def __init__(self, distribution_package: DistributionPackage, path: pathlib.Path):
         self.distribution_package: DistributionPackage = distribution_package
         self.path: pathlib.Path = path
         project_root: pathlib.Path = distribution_package.prepare_source(path)
-        self.project: Project = Project(project_root, script_runner)
+        self.project: Project = Project(project_root)
 
 
 class PyPiDistribution(DistributionPackage):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,18 +37,14 @@ def console_script_project_runner(script_runner: ScriptRunner) -> test_support.P
 
 
 @pytest.fixture
-def project(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-    console_script_project_runner: test_support.ProjectRunner,
-) -> test_support.Project:
+def project(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> test_support.Project:
     """
     Creates a temporary directory to serve as the root of a Python project. The returned
     object is an instance of :py:class:`Project`, and the directory can be populated
     with files before invoking ``setup.py pyproject`` with :py:meth:`Project.run()`.
     """
     monkeypatch.chdir(tmp_path)
-    return test_support.Project(tmp_path, console_script_project_runner)
+    return test_support.Project(tmp_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,10 +32,15 @@ else:
 
 
 @pytest.fixture
+def console_script_project_runner(script_runner: ScriptRunner) -> test_support.ProjectRunner:
+    return _project_runner_for(script_runner)
+
+
+@pytest.fixture
 def project(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
-    script_runner: ScriptRunner,
+    console_script_project_runner: test_support.ProjectRunner,
 ) -> test_support.Project:
     """
     Creates a temporary directory to serve as the root of a Python project. The returned
@@ -43,7 +48,7 @@ def project(
     with files before invoking ``setup.py pyproject`` with :py:meth:`Project.run()`.
     """
     monkeypatch.chdir(tmp_path)
-    return test_support.Project(tmp_path, _project_runner_for(script_runner))
+    return test_support.Project(tmp_path, console_script_project_runner)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,34 @@
+import os
 import pathlib
 import pytest
 import test_support
 from pytest_console_scripts import ScriptRunner
-from typing import Iterator, List
+from typing import Iterator, List, Sequence, Union
+
+
+# Once we drop support for Python 3.6 we can probably remove this check since
+# pytest-console-scripts 1.4.0 supports Python 3.7
+if test_support.is_at_least("pytest-console-scripts", "1.4.0"):
+
+    def _project_runner_for(script_runner: ScriptRunner) -> test_support.ProjectRunner:
+        """
+        Return a callable satisfying the :py:class:`test_support.ProjectRunner`
+        protocol that delegates to the given :py:class:`pytest_console_scripts.ScriptRunner`.
+        """
+        return script_runner.run
+
+else:
+
+    def _project_runner_for(script_runner: ScriptRunner) -> test_support.ProjectRunner:
+        """
+        Return a callable satisfying the :py:class:`test_support.ProjectRunner`
+        protocol that delegates to the given :py:class:`pytest_console_scripts.ScriptRunner`.
+        """
+
+        def run(args: Sequence[str], cwd: Union[str, os.PathLike]) -> test_support.ProjectRunResult:
+            return script_runner.run(*args, cwd=cwd)
+
+        return run
 
 
 @pytest.fixture
@@ -17,7 +43,7 @@ def project(
     with files before invoking ``setup.py pyproject`` with :py:meth:`Project.run()`.
     """
     monkeypatch.chdir(tmp_path)
-    return test_support.Project(tmp_path, script_runner)
+    return test_support.Project(tmp_path, _project_runner_for(script_runner))
 
 
 @pytest.fixture(scope="session")

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -23,7 +23,6 @@ from PyPI. But verifying that the procedure above works is the ultimate goal.
 import pathlib
 import pytest
 
-from pytest_console_scripts import ScriptRunner
 from typing import List
 
 # Try importing pyproject_metadata but don't save the module itself because we don't need it
@@ -59,16 +58,14 @@ distributions: List = [
 
 
 @pytest.fixture(params=distributions, ids=lambda ep: ep.test_id)
-def distribution_package(
-    request: pytest.FixtureRequest, tmp_path: pathlib.Path, script_runner: ScriptRunner
-) -> DistributionPackagePreparation:
+def distribution_package(request: pytest.FixtureRequest, tmp_path: pathlib.Path) -> DistributionPackagePreparation:
     """
     Prepare a DistributionPackage for testing. This populates the temporary
     path with the package's source code.
     """
 
     dist: DistributionPackage = request.param
-    return DistributionPackagePreparation(dist, tmp_path, script_runner)
+    return DistributionPackagePreparation(dist, tmp_path)
 
 
 @pytest.mark.needs_network

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -6,7 +6,7 @@ These tests involve actually running the command `setup.py pyproject`.
 import pytest
 import tomlkit
 
-from pytest_console_scripts import RunResult
+from test_support import ProjectRunResult
 from typing import Callable
 
 
@@ -24,7 +24,7 @@ def check_result(result, reference, prefix="running pyproject\n"):
 
 
 @pytest.fixture(params=["script-with-setup.cfg", "script-with-setup.py", "command-with-setup.py"])
-def runner(project, request: pytest.FixtureRequest) -> Callable[[], RunResult]:
+def runner(project, request: pytest.FixtureRequest) -> Callable[[], ProjectRunResult]:
     """
     Provide a function that can be called to run a test, either by calling
     ``python setup.py pyproject``, or by invoking the ``setup-to-pyproject``
@@ -37,7 +37,7 @@ def runner(project, request: pytest.FixtureRequest) -> Callable[[], RunResult]:
         # setup.py exists or not. But if a real setup.py file already exists,
         # presumably it was manually created for the test and is not a stub,
         # so there's no point in running this case.
-        def run() -> RunResult:
+        def run() -> ProjectRunResult:
             if (project.root / "setup.py").exists():
                 pytest.skip("setup.py already exists, skipping setup.cfg-only test")
             return project.run_cli()

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -6,7 +6,7 @@ These tests involve actually running the command `setup.py pyproject`.
 import pytest
 import tomlkit
 
-from test_support import ProjectRunResult
+from test_support import ProjectRunner, ProjectRunResult
 from typing import Callable
 
 
@@ -24,7 +24,7 @@ def check_result(result, reference, prefix="running pyproject\n"):
 
 
 @pytest.fixture(params=["script-with-setup.cfg", "script-with-setup.py", "command-with-setup.py"])
-def runner(project, request: pytest.FixtureRequest) -> Callable[[], ProjectRunResult]:
+def runner(project, request: pytest.FixtureRequest) -> Callable[[ProjectRunner], ProjectRunResult]:
     """
     Provide a function that can be called to run a test, either by calling
     ``python setup.py pyproject``, or by invoking the ``setup-to-pyproject``
@@ -37,10 +37,10 @@ def runner(project, request: pytest.FixtureRequest) -> Callable[[], ProjectRunRe
         # setup.py exists or not. But if a real setup.py file already exists,
         # presumably it was manually created for the test and is not a stub,
         # so there's no point in running this case.
-        def run() -> ProjectRunResult:
+        def run(project_runner: ProjectRunner) -> ProjectRunResult:
             if (project.root / "setup.py").exists():
                 pytest.skip("setup.py already exists, skipping setup.cfg-only test")
-            return project.run_cli()
+            return project.run_cli(project_runner)
 
         return run
     elif request.param == "script-with-setup.py":
@@ -52,7 +52,7 @@ def runner(project, request: pytest.FixtureRequest) -> Callable[[], ProjectRunRe
         raise ValueError(f"Invalid parameter {request.param!r}")
 
 
-def test_name_and_version(project, runner) -> None:
+def test_name_and_version(project, runner, console_script_project_runner: ProjectRunner) -> None:
     """
     Test we can generate a basic project skeleton.
     """
@@ -71,14 +71,14 @@ name = "test-project"
 version = "0.0.1"
 """
     project.setup_cfg(setup_cfg)
-    result = runner()
+    result = runner(console_script_project_runner)
     check_result(result, pyproject_toml)
 
 
 # This next test should be kept up to date as we add support for more fields.
 
 
-def test_everything(project, runner) -> None:
+def test_everything(project, runner, console_script_project_runner: ProjectRunner) -> None:
     """
     Test all fields that the project supports.
     """
@@ -270,5 +270,5 @@ ep2 = "test_project.ep2"
 """
     project.setup_cfg(setup_cfg)
     project.write("README.md", readme_md)
-    result = runner()
+    result = runner(console_script_project_runner)
     check_result(result, pyproject_toml)


### PR DESCRIPTION
This PR alters the `Project` class so we can create it without a `ScriptRunner`; now we pass the `ScriptRunner` to the `run()` or `run_cli()` method instead. This lets us avoid using the `script_runner` fixture in some places where it wasn't really necessary, and was only needed to have a parameter to pass to the `Project` constructor.