### PR TITLE
Fix the non-running of slow tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,4 +79,4 @@ jobs:
           tox -e py
           ${{ inputs.force-minimum-dependencies && '--force-dep setuptools==56 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4' || '' }}
           --
-          ${{ inputs.run-slow && '' || '-m "not slow"' }}
+          ${{ !inputs.run-slow && '-m "not slow"' || '' }}


### PR DESCRIPTION
When I added the feature to skip slow tests in CI under most conditions, I made the classic mistake of using the logical ternary operator pattern `A && B || C` with `B` being something that evaluates to boolean false. So the result was always `C`, i.e. `'-m "not slow"'`, which skips the slow tests.

In this commit I'm flipping the sense of the condition so that I can put the truthy value `'-m "not slow"'` in position `B`, which makes it work properly.

I tested this with [another manually triggered workflow run](https://github.com/diazona/setuptools-pyproject-migration/actions/runs/6404129278), and this time it did run the distribution package tests which are normally skipped.

Closes #86 