### PR TITLE
Set long description content type to text/markdown

### DIFF
--- a/changelog.d/99.bugfix.txt
+++ b/changelog.d/99.bugfix.txt
@@ -1,0 +1,3 @@
+
+Set the long description content type to Markdown in order to
+(hopefully) make the description render properly on PyPI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ author = David Zaslavsky, Stuart Longland
 author_email = diazona@ellipsix.net, me@vk4msl.com
 description = Create a pyproject.toml file from setuptools configuration
 long_description = file:README.md
+long_description_content_type = text/markdown
 url = https://github.com/diazona/setuptools-pyproject-migration
 project_urls =
 	Documentation = https://setuptools-pyproject-migration.readthedocs.io/


### PR DESCRIPTION
Prior to this change, the [description on PyPI](https://pypi.org/project/setuptools-pyproject-migration/) shows up as raw Markdown code. Hopefully this will get PyPI to interpret it as Markdown and show the properly formatted version.

Closes #95