### PR TITLE
Add new changelog entry for description fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,13 @@ Features
 - Enable towncrier (#88)
 
 
+Bugfixes
+--------
+
+- Set the long description content type to Markdown in order to
+  (hopefully) make the description render properly on PyPI. (#99)
+
+
 Improved Documentation
 ----------------------
 

--- a/changelog.d/99.bugfix.txt
+++ b/changelog.d/99.bugfix.txt
@@ -1,3 +1,0 @@
-
-Set the long description content type to Markdown in order to
-(hopefully) make the description render properly on PyPI.


### PR DESCRIPTION
I ran towncrier with a dummy version number and then manually edited CHANGELOG.rst to combine all the release notes under the entry for version 0.1. The goal is to avoid having entries for prereleases in the changelog in the future, because it's generally going to be most useful for people to see differences between final releases.

I did have to "fight" towncrier a little bit because it doesn't want to update a changelog entry for a version that has already been generated. In the future I hope to work out some kind of automation that will handle this the right way.