### PR TITLE
Add missing `packaging` dependency explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,9 @@ jobs:
           allow-prereleases: true
       - name: Install tox
         run: python -m pip install tox
+      - name: Run script checks
+        run: >
+          tox -e script
       - name: Run tests
         # For simplicity, we limit forced minimum dependencies to direct
         # dependencies and build system dependencies, not extra dependencies

--- a/changelog.d/100.bugfix.rst
+++ b/changelog.d/100.bugfix.rst
@@ -1,0 +1,2 @@
+Explicitly list ``packaging`` as a dependency so ``pipx`` installs it in the virtual environment instead of relying on
+``setuptools`` to pull it in.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ package_dir =
 include_package_data = true
 python_requires = >=3.6
 install_requires =
+	packaging
 	pep508-parser
 	setuptools
 	tomlkit
@@ -53,7 +54,6 @@ testing =
 	# local
 	importlib-metadata; \
 		python_version < "3.8"
-	packaging
 	# no version of pyproject-metadata supports Python 3.6
 	pyproject-metadata; \
 		python_version >= "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,13 @@ usedevelop = True
 extras =
 	testing
 
+[testenv:script]
+# Deliberately blank to override the defaults set above
+deps =
+extras =
+commands =
+	setup-to-pyproject --help
+
 # There is very little advantage to using the pre_commit tox environment,
 # compared to running pre-commit directly, but we provide it in case you want to
 # use it. For example, if you don't want to install pre-commit locally.


### PR DESCRIPTION
We were relying on `setuptools` implicitly pulling it in, but it seems that does not happen when `pipx` is used to install everything.  So instead, explicitly list it.

Closes issue #100.