### PR TITLE
Handle README being specified in setup.py

### DIFF
--- a/changelog.d/102.bugfix
+++ b/changelog.d/102.bugfix
@@ -1,0 +1,1 @@
+Add fixes to handle ``README`` data specified in ``setup.py`` instead of ``setup.cfg``.

--- a/changelog.d/102.fixed
+++ b/changelog.d/102.fixed
@@ -1,1 +1,0 @@
-Add fixes to handle `README` data specified in `setup.py` instead of `setup.cfg`.

--- a/changelog.d/102.fixed
+++ b/changelog.d/102.fixed
@@ -1,0 +1,1 @@
+Add fixes to handle `README` data specified in `setup.py` instead of `setup.cfg`.

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -278,12 +278,10 @@ class WritePyproject(setuptools.Command):
             pyproject["project"]["description"] = description
 
         if dist.get_long_description() not in (None, "UNKNOWN"):
+            long_description_source: str = dist.get_long_description()
+
             if "metadata" in dist.command_options:
-                long_description_source: str = dist.command_options["metadata"]["long_description"][1]
-            else:
-                # setuptools does not tell us where this text came from, so we put it inline so it is at least
-                # preserved!
-                long_description_source: str = dist.get_long_description()
+                long_description_source = dist.command_options["metadata"]["long_description"][1]
 
             long_description_content_type: Optional[str] = dist.metadata.long_description_content_type
 

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -278,10 +278,12 @@ class WritePyproject(setuptools.Command):
             pyproject["project"]["description"] = description
 
         if dist.get_long_description() not in (None, "UNKNOWN"):
-            long_description_source: str = dist.get_long_description()
+            long_description_source: str
 
             if "metadata" in dist.command_options:
                 long_description_source = dist.command_options["metadata"]["long_description"][1]
+            else:
+                long_description_source = dist.get_long_description()
 
             long_description_content_type: Optional[str] = dist.metadata.long_description_content_type
 

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -278,8 +278,15 @@ class WritePyproject(setuptools.Command):
             pyproject["project"]["description"] = description
 
         if dist.get_long_description() not in (None, "UNKNOWN"):
-            long_description_source: str = dist.command_options["metadata"]["long_description"][1]
+            if "metadata" in dist.command_options:
+                long_description_source: str = dist.command_options["metadata"]["long_description"][1]
+            else:
+                # setuptools does not tell us where this text came from, so we put it inline so it is at least
+                # preserved!
+                long_description_source: str = dist.get_long_description()
+
             long_description_content_type: Optional[str] = dist.metadata.long_description_content_type
+
             assert long_description_source
 
             filename: str

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -41,6 +41,31 @@ long_description_content_type = {mime_type}
     assert readme["content-type"] == mime_type
 
 
+@parametrize_readme_type
+def test_string_with_content_type_setuppy(project, extension: str, mime_type: str) -> None:
+    long_description = "This is a long description string"
+    setup_py = f"""\
+import setuptools
+
+setuptools.setup(
+    name="test-project",
+    version="0.0.1",
+    long_description="{long_description}",
+    long_description_content_type="{mime_type}"
+)
+"""
+
+    project.setup_py(setup_py)
+    result = project.generate()
+    readme = result["project"]["readme"]
+    assert isinstance(readme, dict)
+    readme_path: pathlib.Path = pathlib.Path(readme["file"])
+    assert readme_path.suffix == f".{extension}"
+    assert readme_path.exists()
+    assert readme_path.read_text(encoding="utf-8").rstrip("\n") == long_description
+    assert readme["content-type"] == mime_type
+
+
 def test_string_without_content_type(project) -> None:
     long_description = "This is a long description string"
     setup_cfg = f"""\
@@ -52,6 +77,29 @@ long_description = {long_description}
 
     project.setup_cfg(setup_cfg)
     project.setup_py()
+    result = project.generate()
+    readme = result["project"]["readme"]
+    assert isinstance(readme, str)
+    readme_path: pathlib.Path = pathlib.Path(readme)
+    # Without a content type specified, there should be no extension given to the README file
+    assert not readme_path.suffix
+    assert readme_path.exists()
+    assert readme_path.read_text(encoding="utf-8").rstrip("\n") == long_description
+
+
+def test_string_without_content_type_setuppy(project) -> None:
+    long_description = "This is a long description string"
+    setup_py = f"""\
+import setuptools
+
+setuptools.setup(
+    name="test-project",
+    version="0.0.1",
+    long_description="{long_description}"
+)
+"""
+
+    project.setup_py(setup_py)
     result = project.generate()
     readme = result["project"]["readme"]
     assert isinstance(readme, str)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -81,6 +81,26 @@ long_description_content_type = {mime_type}
 
 
 @parametrize_readme_type
+def test_file_with_content_type_setuppy(project, extension: str, mime_type: str) -> None:
+    readme_filename = f"README.{extension}"
+    setup_py = f"""\
+import setuptools
+
+setuptools.setup(
+    name="test-project",
+    version="0.0.1",
+    long_description="file:{readme_filename}",
+    long_description_content_type="{mime_type}"
+)
+"""
+
+    project.write(readme_filename, "Dummy README\n")
+    project.setup_py(setup_py)
+    result = project.generate()
+    assert result["project"]["readme"] == {"content-type": mime_type, "file": readme_filename}
+
+
+@parametrize_readme_type
 def test_file_without_content_type(project, extension: str, mime_type: str) -> None:
     # mime_type is unused but we keep it to be able to use the same parametrization as other tests
     readme_filename = f"README.{extension}"
@@ -94,5 +114,25 @@ long_description = file:{readme_filename}
     project.setup_cfg(setup_cfg)
     project.write(readme_filename, "Dummy README\n")
     project.setup_py()
+    result = project.generate()
+    assert result["project"]["readme"] == readme_filename
+
+
+@parametrize_readme_type
+def test_file_without_content_type_setuppy(project, extension: str, mime_type: str) -> None:
+    # mime_type is unused but we keep it to be able to use the same parametrization as other tests
+    readme_filename = f"README.{extension}"
+    setup_py = f"""\
+import setuptools
+
+setuptools.setup(
+    name="test-project",
+    version="0.0.1",
+    long_description="file:{readme_filename}"
+)
+"""
+
+    project.write(readme_filename, "Dummy README\n")
+    project.setup_py(setup_py)
     result = project.generate()
     assert result["project"]["readme"] == readme_filename


### PR DESCRIPTION
Annoyingly, `setuptools` omits the `metadata` property of `command_options`, and this causes the `pyproject.toml` generator to barf rather spectacularly.

So, check for the existence of this key, and if not present, we fail back to using the getter methods and properties of the `Distribution` to retrieve this information.

Fixes issue #102.