### PR TITLE
Use full history and ignore local changes in ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,5 +11,7 @@ build:
   tools:
     python: "3"
   jobs:
+    post_checkout:
+    - '[ "$(git rev-parse --is-shallow-repository)" == "true" ] && git fetch --unshallow --tags'
     pre_install:
     - git update-index --assume-unchanged docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
+  jobs:
+    pre_install:
+    - git update-index --assume-unchanged docs/conf.py

--- a/changelog.d/99.bugfix.txt
+++ b/changelog.d/99.bugfix.txt
@@ -1,0 +1,2 @@
+When building documentation on ReadTheDocs, use a full (non-shallow) clone and
+ignore local modifications, in order to get the right version number


### PR DESCRIPTION
When ReadTheDocs builds our documentation, it runs into a couple of problems determining the version number:

- It uses a shallow clone by default, which won't have the information about the latest Git tag which `setuptools_scm` uses to determine the version number.

    The solution recommended [in ReadTheDocs' documentation](https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone) is to unshallow the clone by fetching the full history as a post-checkout step.
- It makes some local changes to files including `docs/conf.py`. `setuptools_scm` then checks the status of the Git working tree when determining the package version, and comes up with a version number suitable for a local development version, like `0.1.1.dev16+g124dc35.d20231012`, which then appears in the generated documentation. But we want a final release version number like `0.1.1`, at least for versions of the documentation generated from final release tags.

    The solution recommended [in ReadTheDocs' documentation](https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index) is to set the assume-unchanged bit on the modified working tree files so Git doesn't treat them as modified.

This PR implements these two changes. Hopefully this is enough to make the version number look correct.

Closes #99 (hopefully)