### PR TITLE
Strip README path

### DIFF
--- a/changelog.d/111.bugfix.rst
+++ b/changelog.d/111.bugfix.rst
@@ -1,0 +1,1 @@
+Fix converting README ``file:`` directive with whitespace, such as ``file: README.rst``.

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -291,7 +291,7 @@ class WritePyproject(setuptools.Command):
 
             filename: str
             if long_description_source.startswith("file:"):
-                filename = long_description_source[5:]
+                filename = long_description_source[5:].strip()
             else:
                 filename = "README"
                 if long_description_content_type:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -110,6 +110,21 @@ setuptools.setup(
     assert readme_path.read_text(encoding="utf-8").rstrip("\n") == long_description
 
 
+def test_file_with_space(project) -> None:
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+long_description = file: README.rst
+"""
+
+    project.setup_cfg(setup_cfg)
+    project.write("README.rst", "Dummy README\n")
+    project.setup_py()
+    result = project.generate()
+    assert result["project"]["readme"] == "README.rst"
+
+
 @parametrize_readme_type
 def test_file_with_content_type(project, extension: str, mime_type: str) -> None:
     readme_filename = f"README.{extension}"


### PR DESCRIPTION
setuptools allows whitespace after `file:`, as in `file: README.rst`. It needs stripping when converting to TOML, otherwise setuptools will fail to find the README.