### PR TITLE
Improve inline array and table creation

### DIFF
--- a/changelog.d/112.feature.rst
+++ b/changelog.d/112.feature.rst
@@ -1,0 +1,1 @@
+Use inline arrays and tables for keys within the ``project`` key, matching setuptools documentation.

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -21,6 +21,22 @@ def check_result(result, reference, prefix="running pyproject\n"):
     result_parsed = tomlkit.parse(result.stdout[len(prefix) :])
 
     assert result_parsed == reference_parsed
+    check_tomlkit_types_equal(result_parsed, reference_parsed)
+
+
+def check_tomlkit_types_equal(a: object, b: object) -> None:
+    assert type(a) is type(b)
+    if isinstance(a, dict):
+        assert isinstance(b, dict)  # type narrow
+        for k, v in a.items():
+            v2 = b[k]
+            assert type(v) is type(v2)
+            check_tomlkit_types_equal(v, v2)
+    elif isinstance(a, list):
+        assert isinstance(b, list)  # type narrow
+        for v, v2 in zip(a, b):
+            assert type(v) is type(v2)
+            check_tomlkit_types_equal(v, v2)
 
 
 @pytest.fixture(params=["script-with-setup.cfg", "script-with-setup.py", "command-with-setup.py"])
@@ -213,9 +229,18 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Testing",
 ]
+license = {text = "MIT or other license expression"}
+readme = {file = "README.md", content-type = "text/markdown"}
 
-[project.license]
-text = "MIT or other license expression"
+authors = [
+    {name = "David Zaslavsky", email = "diazona@ellipsix.net"},
+    {name = "Stuart Longland", email = "me@vk4msl.com"},
+]
+
+maintainers = [
+    {name = "David Zaslavsky", email = "diazona@ellipsix.net"},
+    {name = "Stuart Longland", email = "me@vk4msl.com"},
+]
 
 [project.optional-dependencies]
 testing = [
@@ -235,26 +260,6 @@ docs = [
     "sphinx-lint",
     "sphinx>=3.5",
 ]
-
-[[project.authors]]
-name = "David Zaslavsky"
-email = "diazona@ellipsix.net"
-
-[[project.authors]]
-name = "Stuart Longland"
-email = "me@vk4msl.com"
-
-[[project.maintainers]]
-name = "David Zaslavsky"
-email = "diazona@ellipsix.net"
-
-[[project.maintainers]]
-name = "Stuart Longland"
-email = "me@vk4msl.com"
-
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
 
 [project.urls]
 Homepage = "https://example.com/test-project"


### PR DESCRIPTION
Follow-up to #112 with some changes I was working on after the comments there.

1. Add a changelog note.
2. Make a generic function for making inline arrays and tables, to unclutter `_generate()`.
3. Don't turn `urls` into an inline table, as it is too cramped.
4. Add recursive assertion on types in `test_setup_command.py`.