### PR TITLE
Change the primary name of the console script to setuptools-pyproject-migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,18 @@ After that, in any directory that has a `setup.py` and/or `setup.cfg` file, you
 can run
 
 ```console
-setup-to-pyproject
+setuptools-pyproject-migration
 ```
 
 and it will print out the content of `pyproject.toml` as computed from your
-`setup.py` and/or `setup.cfg`. Running `setup-to-pyproject -h` will print
-a brief usage summary.
+`setup.py` and/or `setup.cfg`. Running `setuptools-pyproject-migration -h` will
+print a brief usage summary.
+
+You can also install and run the application in one go as follows:
+
+```console
+pipx run setuptools-pyproject-migration
+```
 
 ### Virtual environment
 

--- a/changelog.d/107.removal.txt
+++ b/changelog.d/107.removal.txt
@@ -1,0 +1,1 @@
+Deprecate setup-to-pyproject console script in favor of setuptools-pyproject-migration to support ``pipx run``

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -16,11 +16,18 @@ you can run
 
 .. code-block::
 
-    $ setup-to-pyproject
+    $ setuptools-pyproject-migration
 
 and it will print out the content of ``pyproject.toml`` as computed from your
 ``setup.py`` and/or ``setup.cfg``.
 
-Running ``setup-to-pyproject --help`` will print a brief usage summary.
+Running ``setuptools-pyproject-migration --help`` will print a brief usage
+summary.
+
+You can also install and run the application in one go as follows:
+
+```console
+pipx run setuptools-pyproject-migration
+```
 
 .. _pipx: https://pypa.github.io/pipx/

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ docs =
 
 [options.entry_points]
 console_scripts =
-	setup-to-pyproject = setuptools_pyproject_migration.cli:main
+	setup-to-pyproject = setuptools_pyproject_migration.cli:old_main
+	setuptools-pyproject-migration = setuptools_pyproject_migration.cli:main
 distutils.commands =
 	pyproject = setuptools_pyproject_migration:WritePyproject

--- a/src/setuptools_pyproject_migration/cli.py
+++ b/src/setuptools_pyproject_migration/cli.py
@@ -5,6 +5,7 @@ A simple command-line interface to the plugin.
 import argparse
 import os.path
 import sys
+import warnings
 
 
 def _parse_args() -> argparse.Namespace:
@@ -64,6 +65,14 @@ def main() -> None:
         setup_code = "import setuptools\nsetuptools.setup()\n"
     setup_bytecode = compile(setup_code, "setup.py", "exec", dont_inherit=True)
     exec(setup_bytecode)
+
+
+def old_main() -> None:
+    """
+    Print a deprecation warning and then call :py:func:`main()`.
+    """
+    warnings.warn(f"{sys.argv[0]} is deprecated; run setuptools-pyproject-migration instead", category=FutureWarning)
+    main()
 
 
 # Allow running as `python -m setuptools_pyproject_migration.cli`

--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -163,8 +163,8 @@ setuptools.setup()
 
     def run_cli(self, runner: ProjectRunner) -> ProjectRunResult:
         """
-        Run the console script ``setup-to-pyproject`` on the created project and
-        return the output.
+        Run the console script ``setuptools-pyproject-migration`` on the created
+        project and return the output.
 
         In contrast to :py:meth:`run()`, if ``setup.py`` doesn't exist, it will
         not be created, because the script is supposed to work without it. If
@@ -173,8 +173,8 @@ setuptools.setup()
 
         :param runner: The callable to use to run the script
         """
-        _logger.debug("Running setup-to-pyproject in %s", self.root)
-        return runner(["setup-to-pyproject"], cwd=self.root)
+        _logger.debug("Running setuptools-pyproject-migration in %s", self.root)
+        return runner(["setuptools-pyproject-migration"], cwd=self.root)
 
     def generate(self) -> Pyproject:
         """

--- a/tests/test_deprecated_console_script.py
+++ b/tests/test_deprecated_console_script.py
@@ -1,0 +1,50 @@
+import pytest
+import tomlkit
+
+from test_support import ProjectRunner
+
+
+def test_future_warning(project, console_script_project_runner: ProjectRunner) -> None:
+    """
+    Test that a ``FutureWarning`` is issued when calling the old script name.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+"""
+    project.setup_cfg(setup_cfg)
+    with pytest.warns(FutureWarning):
+        console_script_project_runner(["setup-to-pyproject"], cwd=project.root)
+
+
+def test_name_and_version(project, console_script_project_runner: ProjectRunner) -> None:
+    """
+    Test we can generate a basic project skeleton.
+    """
+    setup_cfg = """\
+[metadata]
+name = test-project
+version = 0.0.1
+"""
+    expected = tomlkit.parse(
+        """\
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-project"
+version = "0.0.1"
+"""
+    )
+    project.setup_cfg(setup_cfg)
+
+    result = console_script_project_runner(["setup-to-pyproject"], cwd=project.root)
+
+    assert result.returncode == 0
+
+    prefix = "running pyproject\n"
+    assert result.stdout.startswith(prefix)
+    actual = tomlkit.parse(result.stdout[len(prefix) :])
+    assert expected == actual


### PR DESCRIPTION
This PR changes the name of the console script that users should use to match the name of the package, `setuptools-pyproject-migration`, to support `pipx run`.

We could have kept multiple console script names, but I thought that was more confusion than it's worth.

The intent will be to remove the old console script name in some future version, though I'm not sure if it makes sense to advertise a specific version in which it will be removed or how long we should wait before actually removing it. (Especially given that it didn't even seem to work properly, see #100)

Closes #107