### PR TITLE
Use simpler shell syntax to deepen repository checkout

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@ build:
     python: "3"
   jobs:
     post_checkout:
-    - '[ "$(git rev-parse --is-shallow-repository)" == "true" ] && git fetch --unshallow --tags'
+    - 'git fetch --unshallow --tags || true'
     pre_install:
     - git update-index --assume-unchanged docs/conf.py


### PR DESCRIPTION
The shell used by ReadTheDocs seems to have a problem with the command used to check if a repository is shallow, so I'm replacing the use of `[` (equivalent to the `test` builtin) with a simple pipeline that uses minimal shell syntax, just a single `||` operator.

Closes #124 