### PR TITLE
Fix a couple syntax errors in documentation

### DIFF
--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -26,8 +26,8 @@ summary.
 
 You can also install and run the application in one go as follows:
 
-```console
-pipx run setuptools-pyproject-migration
-```
+.. code-block::
+
+    $ pipx run setuptools-pyproject-migration
 
 .. _pipx: https://pypa.github.io/pipx/

--- a/test_support/test_support/distribution.py
+++ b/test_support/test_support/distribution.py
@@ -289,7 +289,7 @@ class PyPiDistribution(DistributionPackage):
         straight from the filesystem when running their ``setup.py`` file. This
         flag can be set to ``True`` to make that happen during testing.
 
-    .. `sdist specification`: https://packaging.python.org/en/latest/specifications/source-distribution-format/
+    .. _sdist specification: https://packaging.python.org/en/latest/specifications/source-distribution-format/
     """
 
     def __init__(


### PR DESCRIPTION
Fairly straightforward, just fixing a couple of errors. In both cases I lamented the lack of a good pre-commit hook to catch this sort of thing, so maybe we can find one and add it in the future.

Closes #129
Closes #130