### PR TITLE
Update tests to use Python 3.12 as the latest stable version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
         python:
         - "3.6"
         - "3.8"
-        - "3.11"
         - "3.12"
         platform:
         # This package is supposed to be OS-independent and is unlikely to have
@@ -48,7 +47,7 @@ jobs:
           force-minimum-dependencies: false
         # For testing forced minimum deps, use the latest stable version of Python
         # on which those dependencies can be installed
-        - python: "3.11"
+        - python: "3.12"
           platform: ubuntu-latest
           force-minimum-dependencies: true
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         python:
         - "3.6"
         - "3.8"
-        - "3.11"
+        - "3.12"
         platform:
         - ubuntu-latest
         - macos-latest
@@ -54,7 +54,7 @@ jobs:
         - python: "3.10"
           platform: ubuntu-latest
           force-minimum-dependencies: false
-        - python: "3.12"
+        - python: "3.11"
           platform: ubuntu-latest
           force-minimum-dependencies: false
         - python: pypy3.6
@@ -75,7 +75,7 @@ jobs:
         - python: "3.6"
           platform: ubuntu-20.04
           force-minimum-dependencies: true
-        - python: "3.11"
+        - python: "3.12"
           platform: ubuntu-latest
           force-minimum-dependencies: true
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ env:
 jobs:
   test:
     runs-on: ${{ inputs.platform }}
-    continue-on-error: ${{ inputs.python-version == '3.12' }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/changelog.d/+py312.misc.txt
+++ b/changelog.d/+py312.misc.txt
@@ -1,0 +1,1 @@
+Update tests to use Python 3.12 as the latest stable version


### PR DESCRIPTION
This PR includes a couple changes to the Github Actions workflows so that they use Python 3.12 as the latest stable version. When these workflows were written, 3.12 had not been finalized yet so we were using 3.11 as the latest stable version.