### PR TITLE
Work around incompatibility between Python 3.12 and setuptools<66.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,14 @@ jobs:
         # Note the -- used to separate tox options from pytest options.
         run: >
           tox -e py
-          ${{ inputs.force-minimum-dependencies && '--force-dep setuptools==56 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4' || '' }}
+          ${{
+            inputs.force-minimum-dependencies
+            && (
+              inputs.python-version >= '3.12'
+              && '--force-dep setuptools==66.1 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4'
+              || '--force-dep setuptools==56 --force-dep setuptools_scm==3.4.1 --force-dep typing-extensions==4'
+            )
+            || ''
+          }}
           --
           ${{ !inputs.run-slow && '-m "not slow"' || '' }}

--- a/changelog.d/139.bugfix.rst
+++ b/changelog.d/139.bugfix.rst
@@ -1,0 +1,1 @@
+Require ``setuptools>=66.1`` when running on Python 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,8 @@ python_requires = >=3.6
 install_requires =
 	packaging
 	pep508-parser
-	setuptools
+	setuptools; python_version < "3.12"
+	setuptools >= 66.1; python_version >= "3.12"
 	tomlkit
 	typing-extensions >=4, <5
 


### PR DESCRIPTION
Older versions of setuptools fail to import distutils on Python 3.12, presumably due to the removal of distutils from the standard library. This bug was fixed in https://github.com/pypa/setuptools/pull/3685, and setuptools 66.1 was the first version released that includes the fix. (I'm not sure exactly how that PR fixed the bug, but it doesn't matter.)

Because setuptools 66.0 understandably does not declare itself to be incompatible with Python 3.12, I'm bumping our minimum setuptools version requirement on that Python version to reflect the incompatibility, and adjusting the CI configuration to match.

Closes #139 