### PR TITLE
Reduce the pre-commit autoupdate frequency to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
   - id: towncrier-check
     files: $changelog\.d/
 ci:
+  autoupdate_schedule: monthly
   skip:
   # pre-commit.ci doesn't have Docker available
   - actionlint-docker

--- a/changelog.d/109.misc.rst
+++ b/changelog.d/109.misc.rst
@@ -1,0 +1,1 @@
+Reduce pre-commit.ci autoupdate frequency to monthly


### PR DESCRIPTION
It's kind of annoying to deal with weekly updates because we always have to revert the changes to the ruff hook, at least as long as we want to keep supporting Python 3.6. So I'm changing it to monthly. We could decide to further reduce the frequency or drop usage of pre-commit.ci entirely in the future.

Closes #109

I'd probably recommend merging this after #138, but I'm not sure if it matters.