### PR TITLE
Handle INI-style strings for `entry_points`

### DIFF
--- a/changelog.d/152.bugfix.rst
+++ b/changelog.d/152.bugfix.rst
@@ -1,0 +1,1 @@
+Handle INI-style ``entry_point`` strings.

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -1,10 +1,10 @@
+import configparser
 import itertools
 import mimetypes
 import setuptools
 import sys
 import tomlkit
 import warnings
-import configparser
 from packaging.specifiers import SpecifierSet
 from pep508_parser import parser as pep508
 from tomlkit.api import Array, InlineTable

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -127,3 +127,43 @@ def test_generate_all_entrypoints(make_write_pyproject):
             "eels": "montypython.somethingcompletelydifferent:eels",
         },
     }
+
+
+def test_generate_ini_entrypoints(make_write_pyproject):
+    """
+    Test distribution with INI-style entry_points
+    """
+    # https://github.com/diazona/setuptools-pyproject-migration/issues/152
+    cmd = make_write_pyproject(
+        entry_points="""
+            [console_scripts]
+            spanish-inquisition=montypython.unexpected:spanishinquisition
+            brian=montypython.naughtyboy:brian
+
+            [gui_scripts]
+            dead-parrot=montypython.sketch:petshop
+            shrubbery=montypython.holygrail:knightswhosayni
+
+            [project.plugins]
+            babysnatchers=montypython.somethingcompletelydifferent:babysnatchers
+            eels=montypython.somethingcompletelydifferent:eels
+        """
+    )
+    result = cmd._generate()
+
+    assert result["project"]["scripts"] == {
+        "spanish-inquisition": "montypython.unexpected:spanishinquisition",
+        "brian": "montypython.naughtyboy:brian",
+    }
+
+    assert result["project"]["gui-scripts"] == {
+        "dead-parrot": "montypython.sketch:petshop",
+        "shrubbery": "montypython.holygrail:knightswhosayni",
+    }
+
+    assert result["project"]["entry-points"] == {
+        "project.plugins": {
+            "babysnatchers": "montypython.somethingcompletelydifferent:babysnatchers",
+            "eels": "montypython.somethingcompletelydifferent:eels",
+        },
+    }


### PR DESCRIPTION
A number of Python projects use this somewhat ugly syntax for specifying entry points.  So we need to support it sadly.

Closes #152.