### PR TITLE
Add more robust handling of long descriptions

### DIFF
--- a/changelog.d/132.bugfix.rst
+++ b/changelog.d/132.bugfix.rst
@@ -1,0 +1,1 @@
+Add more robust handling of long descriptions and their content types

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ package_dir =
 include_package_data = true
 python_requires = >=3.6
 install_requires =
+	dataclasses; python_version < "3.7"
 	packaging
 	pep508-parser
 	setuptools; python_version < "3.12"

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -7,21 +7,9 @@ import tomlkit
 import warnings
 from packaging.specifiers import SpecifierSet
 from pep508_parser import parser as pep508
+from setuptools_pyproject_migration._types import Contributor, Pyproject
 from tomlkit.api import Array, InlineTable
-from typing import Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
-
-# After we drop support for Python <3.10, we can import TypeAlias directly from typing
-from typing_extensions import Required, TypedDict
-
-
-# PEP 518
-BuildSystem: Type = TypedDict("BuildSystem", {"requires": List[str], "build-backend": str}, total=True)
-
-# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
-Contributor: Type = TypedDict("Contributor", {"name": str, "email": str}, total=False)
-LicenseFile: Type = TypedDict("LicenseFile", {"file": str})
-LicenseText: Type = TypedDict("LicenseText", {"text": str})
-ReadmeInfo: Type = TypedDict("ReadmeInfo", {"file": str, "content-type": str})
+from typing import Dict, List, Optional, Set, Tuple, TypeVar, Union
 
 
 def _parse_entry_point(entry_point: str) -> Tuple[str, str]:
@@ -120,38 +108,6 @@ def _generate_entry_points(entry_points: Optional[Union[Dict[str, List[str]], st
 
     return parsed_entry_points
 
-
-Project: Type = TypedDict(
-    "Project",
-    {
-        "authors": List[Contributor],
-        "classifiers": List[str],
-        "dependencies": List[str],
-        "description": str,
-        "dynamic": List[str],
-        "entry-points": Dict[str, Dict[str, str]],
-        "gui-scripts": Dict[str, str],
-        "keywords": List[str],
-        "license": Union[LicenseFile, LicenseText],
-        "maintainers": List[Contributor],
-        "name": Required[str],
-        "optional-dependencies": Dict[str, List[str]],
-        "readme": Union[str, ReadmeInfo],
-        "requires-python": str,
-        "scripts": Dict[str, str],
-        "urls": Dict[str, str],
-        "version": str,
-    },
-    total=False,
-)
-
-Pyproject: Type = TypedDict("Pyproject", {"build-system": BuildSystem, "project": Project}, total=False)
-"""
-The type of the data structure stored in a ``pyproject.toml`` file. This only
-includes the build system and core metadata portions, i.e. the ``build-system``
-and ``project`` tables. The data structure may contain other entries that are
-not constrained by this type.
-"""
 
 T = TypeVar("T")
 

--- a/src/setuptools_pyproject_migration/__init__.py
+++ b/src/setuptools_pyproject_migration/__init__.py
@@ -1,12 +1,11 @@
 import configparser
 import itertools
-import mimetypes
 import setuptools
 import sys
 import tomlkit
-import warnings
 from packaging.specifiers import SpecifierSet
 from pep508_parser import parser as pep508
+from setuptools_pyproject_migration._long_description import LongDescriptionMetadata
 from setuptools_pyproject_migration._types import Contributor, Pyproject
 from tomlkit.api import Array, InlineTable
 from typing import Dict, List, Optional, Set, Tuple, TypeVar, Union
@@ -191,55 +190,6 @@ class WritePyproject(setuptools.Command):
                 contributors.append(contributor)
         return contributors
 
-    @staticmethod
-    def _guess_readme_extension(content_type: str) -> Optional[str]:
-        """
-        Return the file extension that most canonically implies the given content
-        type, focused mainly on content types that might plausibly be used for
-        a README file. In particular, it respects the two mappings between
-        content type and extension that are specified in `the packaging spec for
-        ``pyproject.toml`` <https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#readme>`_:
-
-        >>> WritePyproject._guess_readme_extension("text/markdown")
-        '.md'
-        >>> WritePyproject._guess_readme_extension("text/x-rst")
-        '.rst'
-
-        Plain text is also a common type. For explicitness, this returns an actual
-        extension rather than omitting one, even though a file named just
-        ``README`` will generally also be understood as plain text:
-
-        >>> WritePyproject._guess_readme_extension("text/plain")
-        '.txt'
-
-        Any `parameters <https://packaging.python.org/en/latest/specifications/core-metadata/#description-content-type>`_
-        present will be ignored.
-
-        >>> WritePyproject._guess_readme_extension("text/markdown; charset=iso-8859-1; variant=GFM")
-        '.md'
-        >>> WritePyproject._guess_readme_extension("text/x-rst; charset=ascii")
-        '.rst'
-        >>> WritePyproject._guess_readme_extension("text/plain; charset=utf-8")
-        '.txt'
-        """  # noqa: E501
-
-        content_type = content_type.lower().partition(";")[0]
-        # .md and .rst are called out specifically in the packaging specification
-        # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#readme
-        if content_type == "text/markdown":
-            return ".md"
-        elif content_type == "text/x-rst":
-            return ".rst"
-        # Python <3.8 returns an arbitrary one from among all extensions associated
-        # with the content type, so we override it to return the most likely one for
-        # common README content types
-        # - https://github.com/python/cpython/issues/40993
-        # - https://github.com/python/cpython/issues/51048
-        elif content_type == "text/plain":
-            return ".txt"
-        else:
-            return mimetypes.guess_extension(content_type)
-
     def _generate(self) -> Pyproject:
         """
         Create the raw data structure containing the information from
@@ -305,44 +255,8 @@ class WritePyproject(setuptools.Command):
             pyproject["project"]["description"] = description
 
         if dist.get_long_description() not in (None, "UNKNOWN"):
-            long_description_source: str
-
-            if "metadata" in dist.command_options:
-                long_description_source = dist.command_options["metadata"]["long_description"][1]
-            else:
-                long_description_source = dist.get_long_description()
-
-            long_description_content_type: Optional[str] = dist.metadata.long_description_content_type
-
-            assert long_description_source
-
-            filename: str
-            if long_description_source.startswith("file:"):
-                filename = long_description_source[5:].strip()
-            else:
-                filename = "README"
-                if long_description_content_type:
-                    extension: Optional[str] = self._guess_readme_extension(long_description_content_type)
-                    if extension:
-                        filename += extension
-                    else:
-                        warnings.warn(f"Could not guess extension for content type {long_description_content_type}")
-                # If the long description is a hard-coded string, we need to write it out to
-                # a file because pyproject.toml only allows specifying a filename, not a string.
-                with open(filename, "w") as f:
-                    f.write(long_description_source)
-
-            if long_description_content_type:
-                pyproject["project"]["readme"] = _tomlkit_inlinify(
-                    {"file": filename, "content-type": long_description_content_type}
-                )
-
-            else:
-                # By setting readme_info to a string, we can avoid making any assumptions about
-                # the content type. The general approach in this package is to directly
-                # translate the information from setuptools without injecting additional
-                # information not provided by the user.
-                pyproject["project"]["readme"] = filename
+            long_description = LongDescriptionMetadata.from_distribution(dist)
+            pyproject["project"]["readme"] = _tomlkit_inlinify(long_description.pyproject_readme())
 
         # Technically the dist.python_requires field contains an instance of
         # setuptools.external.packaging.specifiers.SpecifierSet.

--- a/src/setuptools_pyproject_migration/_long_description.py
+++ b/src/setuptools_pyproject_migration/_long_description.py
@@ -1,0 +1,164 @@
+"""
+Code for computing the long description and its content type.
+"""
+
+import dataclasses
+import logging
+import mimetypes
+import pathlib
+import setuptools.dist
+import warnings
+
+from setuptools_pyproject_migration._types import ReadmeInfo
+from typing import Optional, Union
+
+
+_logger = logging.getLogger("setuptools_pyproject_migration")
+
+
+@dataclasses.dataclass
+class LongDescriptionMetadata:
+    """
+    Metadata related to the long description.
+    """
+
+    text: str
+    """The raw description text."""
+
+    content_type: Optional[str] = None
+    """The content type associated with the description."""
+
+    path: Optional[pathlib.Path] = None
+    """The path to a file whose content is the description text."""
+
+    @staticmethod
+    def from_distribution(dist: setuptools.dist.Distribution) -> "LongDescriptionMetadata":
+        """
+        Construct a ``LongDescriptionMetadata`` object by reading the metadata
+        from a ``Distribution``.
+
+        :param dist: The ``Distribution`` from which to compute the long
+            description metadata.
+        :raise RuntimeError: If no content type could be determined from the
+            distribution metadata.
+        """
+        text: str
+        content_type: Optional[str] = dist.metadata.long_description_content_type
+        path: pathlib.Path
+
+        raw: str = _raw_long_description_value(dist)
+
+        if raw.startswith("file:"):
+            path = pathlib.Path(raw[5:].strip())
+            text = _read_long_description_file(path)
+        else:
+            # We don't have access to the filename, so we have to use some
+            # heuristics to either guess what it should be or come up with
+            # a reasonable filename of our own.
+            filename = "README"
+            if content_type:
+                extension: Optional[str] = _guess_readme_extension(content_type)
+                if extension:
+                    filename += extension
+                else:
+                    warnings.warn(f"Could not guess extension for content type {content_type}")
+            path = pathlib.Path(filename)
+            del filename
+            text = raw
+            # If the long description is a hard-coded string, we need to write it out to
+            # a file because pyproject.toml only allows specifying a filename, not a string.
+            path.write_text(text)
+
+        if content_type:
+            return LongDescriptionMetadata(text, content_type, path)
+        else:
+            return LongDescriptionMetadata(text, path=path)
+
+    def pyproject_readme(self) -> Union[str, ReadmeInfo]:
+        """
+        Compute the value that should be added to the ``pyproject.readme`` entry
+        in ``pyproject.toml`` to represent this long description.
+
+        >>> LongDescriptionMetadata("Description", "text/plain", pathlib.Path("readme.txt")).pyproject_readme()
+        {'file': 'readme.txt', 'content-type': 'text/plain'}
+
+        This class does not make any assumptions about the content type, so it
+        will not emit a content type if one was not provided.
+
+        >>> LongDescriptionMetadata("Description", None, pathlib.Path("readme.txt")).pyproject_readme()
+        'readme.txt'
+        """
+        if self.content_type:
+            return {"file": str(self.path), "content-type": self.content_type}
+        else:
+            return str(self.path)
+
+
+def _raw_long_description_value(dist: setuptools.dist.Distribution) -> str:
+    """
+    Return the raw value of the ``long_description`` option given to setuptools.
+
+    This will be either the value in ``setup.cfg``, or the value passed to
+    the ``setup()`` function.
+    """
+    if "metadata" in dist.command_options:
+        return dist.command_options["metadata"]["long_description"][1]
+    else:
+        return dist.get_long_description()
+
+
+def _read_long_description_file(path: pathlib.Path) -> str:
+    """
+    Read the content of the long description from a filename.
+    """
+    # TODO handle multiple comma-separated filenames
+    return path.read_text()
+
+
+def _guess_readme_extension(content_type: str) -> Optional[str]:
+    """
+    Return the file extension that most canonically implies the given content
+    type, focused mainly on content types that might plausibly be used for
+    a README file. In particular, it respects the two mappings between
+    content type and extension that are specified in `the packaging spec for
+    ``pyproject.toml`` <https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#readme>`_:
+
+    >>> _guess_readme_extension("text/markdown")
+    '.md'
+    >>> _guess_readme_extension("text/x-rst")
+    '.rst'
+
+    Plain text is also a common type. For explicitness, this returns an actual
+    extension rather than omitting one, even though a file named just
+    ``README`` will generally also be understood as plain text:
+
+    >>> _guess_readme_extension("text/plain")
+    '.txt'
+
+    Any `parameters <https://packaging.python.org/en/latest/specifications/core-metadata/#description-content-type>`_
+    present will be ignored.
+
+    >>> _guess_readme_extension("text/markdown; charset=iso-8859-1; variant=GFM")
+    '.md'
+    >>> _guess_readme_extension("text/x-rst; charset=ascii")
+    '.rst'
+    >>> _guess_readme_extension("text/plain; charset=utf-8")
+    '.txt'
+    """  # noqa: E501
+
+    content_type = content_type.lower().partition(";")[0]
+    # .md and .rst are called out specifically in the packaging specification
+    # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#readme
+    if content_type == "text/markdown":
+        return ".md"
+    elif content_type == "text/x-rst":
+        return ".rst"
+    # Python <3.8 returns an arbitrary one from among all extensions associated
+    # with the content type, so we override it to return the most likely one for
+    # common README content types
+    # - https://github.com/python/cpython/issues/40993
+    # - https://github.com/python/cpython/issues/51048
+    elif content_type == "text/plain":
+        return ".txt"
+    else:
+        return mimetypes.guess_extension(content_type)

--- a/src/setuptools_pyproject_migration/_long_description.py
+++ b/src/setuptools_pyproject_migration/_long_description.py
@@ -113,9 +113,18 @@ def _raw_long_description_value(dist: setuptools.dist.Distribution) -> str:
     This will be either the value in ``setup.cfg``, or the value passed to
     the ``setup()`` function.
     """
-    if "metadata" in dist.command_options:
+    try:
+        # If this is present, it contains the raw text value of the
+        # long_description option from setup.cfg. (Or, it should. Otherwise we'd
+        # have to manually parse setup.cfg to get it.) If it names a file,
+        # get_long_description() should give the string obtained by
+        # reading the file.
         return dist.command_options["metadata"]["long_description"][1]
-    else:
+    except KeyError:
+        # If the option comes from setup.py then get_long_description()
+        # gives us the raw value instead. We can't necessarily get the
+        # filename this way because setup() might never receive the
+        # filename if the file was read directly by setup.py.
         return dist.get_long_description()
 
 

--- a/src/setuptools_pyproject_migration/_long_description.py
+++ b/src/setuptools_pyproject_migration/_long_description.py
@@ -33,19 +33,29 @@ class LongDescriptionMetadata:
     """The path to a file whose content is the description text."""
 
     @staticmethod
-    def from_distribution(dist: setuptools.dist.Distribution) -> "LongDescriptionMetadata":
+    def from_distribution(
+        dist: setuptools.dist.Distribution, *, override_content_type: Optional[str] = None
+    ) -> "LongDescriptionMetadata":
         """
         Construct a ``LongDescriptionMetadata`` object by reading the metadata
         from a ``Distribution``.
 
         :param dist: The ``Distribution`` from which to compute the long
             description metadata.
-        :raise RuntimeError: If no content type could be determined from the
-            distribution metadata.
+        :param content_type: Override the computed content type of the long
+            description, or ``None`` to skip any override and raise an error
+            if no content type could be determined.
+        :raise RuntimeError: If no content type could be determined either from
+            ``override_content_type`` or from the distribution metadata.
         """
         text: str
         content_type: Optional[str] = dist.metadata.long_description_content_type
         path: Optional[pathlib.Path]
+
+        if override_content_type:
+            if content_type and content_type != override_content_type:
+                _logger.warning("Overriding original content type %s with %s", content_type, override_content_type)
+            content_type = override_content_type
 
         raw: str = _raw_long_description_value(dist)
 

--- a/src/setuptools_pyproject_migration/_types.py
+++ b/src/setuptools_pyproject_migration/_types.py
@@ -1,0 +1,46 @@
+from typing import Dict, List, Type, Union
+
+# After we drop support for Python <3.10, we can import TypeAlias directly from typing
+from typing_extensions import Required, TypedDict
+
+
+# PEP 518
+BuildSystem: Type = TypedDict("BuildSystem", {"requires": List[str], "build-backend": str}, total=True)
+
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+Contributor: Type = TypedDict("Contributor", {"name": str, "email": str}, total=False)
+LicenseFile: Type = TypedDict("LicenseFile", {"file": str})
+LicenseText: Type = TypedDict("LicenseText", {"text": str})
+ReadmeInfo: Type = TypedDict("ReadmeInfo", {"file": str, "content-type": str})
+
+Project: Type = TypedDict(
+    "Project",
+    {
+        "authors": List[Contributor],
+        "classifiers": List[str],
+        "dependencies": List[str],
+        "description": str,
+        "dynamic": List[str],
+        "entry-points": Dict[str, Dict[str, str]],
+        "gui-scripts": Dict[str, str],
+        "keywords": List[str],
+        "license": Union[LicenseFile, LicenseText],
+        "maintainers": List[Contributor],
+        "name": Required[str],
+        "optional-dependencies": Dict[str, List[str]],
+        "readme": Union[str, ReadmeInfo],
+        "requires-python": str,
+        "scripts": Dict[str, str],
+        "urls": Dict[str, str],
+        "version": str,
+    },
+    total=False,
+)
+
+Pyproject: Type = TypedDict("Pyproject", {"build-system": BuildSystem, "project": Project}, total=False)
+"""
+The type of the data structure stored in a ``pyproject.toml`` file. This only
+includes the build system and core metadata portions, i.e. the ``build-system``
+and ``project`` tables. The data structure may contain other entries that are
+not constrained by this type.
+"""

--- a/src/setuptools_pyproject_migration/_types.py
+++ b/src/setuptools_pyproject_migration/_types.py
@@ -11,7 +11,8 @@ BuildSystem: Type = TypedDict("BuildSystem", {"requires": List[str], "build-back
 Contributor: Type = TypedDict("Contributor", {"name": str, "email": str}, total=False)
 LicenseFile: Type = TypedDict("LicenseFile", {"file": str})
 LicenseText: Type = TypedDict("LicenseText", {"text": str})
-ReadmeInfo: Type = TypedDict("ReadmeInfo", {"file": str, "content-type": str})
+ReadmeFile: Type = TypedDict("ReadmeFile", {"file": str, "content-type": str})
+ReadmeText: Type = TypedDict("ReadmeText", {"text": str, "content-type": str})
 
 Project: Type = TypedDict(
     "Project",
@@ -28,7 +29,7 @@ Project: Type = TypedDict(
         "maintainers": List[Contributor],
         "name": Required[str],
         "optional-dependencies": Dict[str, List[str]],
-        "readme": Union[str, ReadmeInfo],
+        "readme": Union[str, ReadmeFile, ReadmeText],
         "requires-python": str,
         "scripts": Dict[str, str],
         "urls": Dict[str, str],

--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -183,11 +183,10 @@ setuptools.setup()
         _logger.debug("Running %r in %s", " ".join(cmdargs), self.root)
         return runner(cmdargs, cwd=self.root)
 
-    def generate(self, *, extra_args: Optional[Iterable[str]] = None) -> Pyproject:
+    def distribution(self, *, extra_args: Optional[Iterable[str]] = None) -> setuptools.dist.Distribution:
         """
-        Run the equivalent of ``setup.py pyproject`` but return the generated
-        data structure that would go into pyproject.toml instead of writing it
-        out.
+        Run ``setup.py`` but stop before actually executing any commands, and
+        instead return the ``Distribution`` object.
         """
         if not (self.root / "setup.py").exists():
             self.setup_py()
@@ -213,6 +212,16 @@ setuptools.setup()
         #
         # If this assertion ever fails we will need to find some kind of workaround.
         assert isinstance(distribution, setuptools.dist.Distribution)
+        return distribution
+
+    def generate(self, *, extra_args: Optional[Iterable[str]] = None) -> Pyproject:
+        """
+        Run the equivalent of ``setup.py pyproject`` but return the generated
+        data structure that would go into pyproject.toml instead of writing it
+        out.
+        """
+
+        distribution = self.distribution(extra_args=extra_args)
 
         # setuptools wants each command class to be a singleton; among other
         # reasons, this means setuptools can automatically set command options

--- a/tests/test_long_description_utilities.py
+++ b/tests/test_long_description_utilities.py
@@ -1,0 +1,72 @@
+"""
+Tests of the utilities that manipulate the long description.
+"""
+
+import pathlib
+import pytest
+import setuptools.dist
+
+from setuptools_pyproject_migration._long_description import LongDescriptionMetadata, _guess_path
+from setuptools_pyproject_migration._types import ReadmeFile, ReadmeText
+from typing import Optional, Union
+
+
+def test_guess_path_with_no_file(project):
+    project.setup_py()
+    distribution: setuptools.dist.Distribution = project.distribution()
+    result = _guess_path(distribution, "This is a long description", "text/plain")
+    assert result is None
+
+
+def test_guess_path_with_description_file_metadata(project):
+    readme_path = pathlib.Path("README.txt")
+    description = "This is a long description"
+    project.setup_cfg(
+        f"""
+[metadata]
+description_file = {readme_path!s}
+"""
+    )
+    project.setup_py()
+    distribution: setuptools.dist.Distribution = project.distribution()
+    result = _guess_path(distribution, description, "text/plain")
+    assert result == readme_path
+
+
+def test_guess_path_with_file(project):
+    readme_path = pathlib.Path("README.txt")
+    description = "This is a long description"
+    project.write(readme_path, description)
+    project.setup_py()
+    distribution: setuptools.dist.Distribution = project.distribution()
+    result = _guess_path(distribution, description, "text/plain")
+    assert result == readme_path
+
+
+@pytest.mark.parametrize(
+    ["text", "content_type", "path", "expected"],
+    [
+        ("Description", "text/plain", "path.txt", {"file": "path.txt", "content-type": "text/plain"}),
+        ("Description", "text/plain", None, {"text": "Description", "content-type": "text/plain"}),
+        ("Description", None, "path.txt", "path.txt"),
+        ("Description", "text/plain", "path.md", {"file": "path.md", "content-type": "text/plain"}),
+    ],
+    ids=["file-dict", "text-dict", "filename-str", "mismatched-content-type"],
+)
+def test_long_description_metadata_rendering(
+    text: str, content_type: Optional[str], path: Optional[str], expected: Union[str, ReadmeFile, ReadmeText]
+):
+    actual = LongDescriptionMetadata(text, content_type, pathlib.Path(path) if path else None).pyproject_readme()
+    assert actual == expected
+
+
+def test_long_description_metadata_with_only_text():
+    metadata = LongDescriptionMetadata("Description", None, None)
+    with pytest.raises(ValueError):
+        metadata.pyproject_readme()
+
+
+def test_long_description_metadata_with_no_extension():
+    metadata = LongDescriptionMetadata("Description", None, pathlib.Path("path"))
+    with pytest.raises(ValueError):
+        metadata.pyproject_readme()


### PR DESCRIPTION
This PR makes some major improvements in how we handle the `long_description` field from setuptools:

- Now if the long description is given as an inline string in `setup.cfg` or `setup.py` (as far as we can tell) rather than being loaded from a file, it will be kept as an inline string in `pyproject.toml`.
- If there's no content type provided and one cannot be definitively determined from the file extension, the user can provide it with a new option `--readme-content-type`; otherwise the program will guess `text/plain`.
- It fixes the error where the long description would sometimes be missing from the command options, closing #132.
- The code is refactored to be more modular and more testable.

Thanks to contributors on [a Mastodon thread](https://techhub.social/@diazona/112736102428118730) for some useful discussion.