### PR TITLE
Support passing command line arguments to setup.py from test code

### DIFF
--- a/test_support/test_support/__init__.py
+++ b/test_support/test_support/__init__.py
@@ -8,7 +8,7 @@ import setuptools
 import setuptools.dist
 import warnings
 from setuptools_pyproject_migration import Pyproject, WritePyproject
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Union, cast
 
 try:
     # Try importing the third-party package first to get the most up-to-date
@@ -203,7 +203,16 @@ setuptools.setup()
         #
         # If this assertion ever fails we will need to find some kind of workaround.
         assert isinstance(distribution, setuptools.dist.Distribution)
-        command: WritePyproject = WritePyproject(distribution)
+
+        # setuptools wants each command class to be a singleton; among other
+        # reasons, this means setuptools can automatically set command options
+        # as attributes on the single instance of the command class. (See
+        # Distribution._set_command_options() for details.) The single instance
+        # is supposed to be created by get_command_obj(). So we use that here
+        # rather than constructing an instance of the class directly.
+        command: WritePyproject = cast(WritePyproject, distribution.get_command_obj("pyproject"))
+        assert isinstance(command, WritePyproject)
+
         return command._generate()
 
 


### PR DESCRIPTION
While working on #156 I found it useful to support passing testing command-line options when we run `setup.py` from our test code. In order to support that I had to make a couple other infrastructure changes as well, most notably abiding by the "singleton rule" for setuptools `Command`s. I thought it would be helpful to split this out as a separate pull request.

This PR fixes the prerequisite issues and adds the ability to pass extra arguments through each of the `Project` methods that invokes `setup()`.
