### PR TITLE
Apply xfail markers to individual test methods in external project tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
   rev: v1.10.1
   hooks:
   - id: mypy
+    exclude: "conftest\\.py$"
     additional_dependencies:
     - pyproject-metadata
     - setuptools

--- a/changelog.d/+distribute.misc.rst
+++ b/changelog.d/+distribute.misc.rst
@@ -1,0 +1,1 @@
+Apply xfail markers to individual test methods in external project tests and enable xfail_strict

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,3 +37,4 @@ pythonpath=test_support
 markers =
 	slow: tests that take a longer time to run
 	needs_network: tests that need to download data from the internet
+xfail_strict=true

--- a/tests/distribution/conftest.py
+++ b/tests/distribution/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from typing import List
+
+
+def pytest_configure(config: pytest.Config):
+    config.addinivalue_line(
+        "markers", "distribute(marks): mark a test group with sub-markers to be applied to individual tests by name"
+    )
+
+
+def pytest_collection_modifyitems(items: List[pytest.Item]):
+    for item in items:
+        base_name, _, _ = item.name.partition("[")
+        try:
+            marker = next(item.iter_markers("distribute"))
+        except StopIteration:
+            continue
+        sub_marker = marker.args[0].get(base_name, None)
+        if sub_marker:
+            item.add_marker(sub_marker)

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -38,16 +38,6 @@ from test_support.distribution import (  # noqa: E402
 )
 
 
-# The return type here is _pytest.mark.structures.ParameterSet but that's not
-# part of pytest's public API so we don't use it.
-# See https://github.com/pytest-dev/pytest/issues/7469
-def _xfail(*args):
-    """
-    Syntactic sugar for marking a test as an expected failure.
-    """
-    return pytest.param(*args, marks=pytest.mark.xfail)
-
-
 def _setuptools_scm_version_conflict() -> bool:
     """
     Check whether the conditions exist to trigger the ``setuptools_scm`` version
@@ -74,11 +64,27 @@ distributions: List = [
     pytest.param(
         PyPiDistribution("pytest", "7.3.0"),
         marks=[
-            pytest.mark.xfail,
+            pytest.mark.distribute(
+                {
+                    "test_dependencies": pytest.mark.xfail,
+                    "test_optional_dependencies": pytest.mark.xfail,
+                    "test_authors": pytest.mark.xfail,
+                    "test_keywords": pytest.mark.xfail,
+                }
+            ),
             pytest.mark.skipif(_setuptools_scm_version_conflict(), reason="Issue #145"),
         ],
     ),
-    _xfail(PyPiDistribution("pytest-localserver", "0.8.0")),
+    pytest.param(
+        PyPiDistribution("pytest-localserver", "0.8.0"),
+        marks=pytest.mark.distribute(
+            {
+                "test_readme": pytest.mark.xfail,
+                "test_dependencies": pytest.mark.xfail,
+                "test_optional_dependencies": pytest.mark.xfail,
+            }
+        ),
+    ),
     PyPiDistribution("aioax25", "0.0.11.post0", make_importable=True),
 ]
 

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -66,10 +66,10 @@ distributions: List = [
         marks=[
             pytest.mark.distribute(
                 {
-                    "test_dependencies": pytest.mark.xfail,
-                    "test_optional_dependencies": pytest.mark.xfail,
-                    "test_authors": pytest.mark.xfail,
-                    "test_keywords": pytest.mark.xfail,
+                    "test_dependencies": pytest.mark.xfail(reason="Issue #133"),
+                    "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
+                    "test_authors": pytest.mark.xfail(reason="Issue #135"),
+                    "test_keywords": pytest.mark.xfail(reason="Issue #136"),
                 }
             ),
             pytest.mark.skipif(_setuptools_scm_version_conflict(), reason="Issue #145"),
@@ -80,8 +80,8 @@ distributions: List = [
         marks=pytest.mark.distribute(
             {
                 "test_readme": pytest.mark.xfail,
-                "test_dependencies": pytest.mark.xfail,
-                "test_optional_dependencies": pytest.mark.xfail,
+                "test_dependencies": pytest.mark.xfail(reason="Issue #135"),
+                "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
             }
         ),
     ),


### PR DESCRIPTION
Our test cases that use external Python projects (the `TestExternalProject` class) currently have a problem: we have a matrix of parameters and test methods, but up to this point there has been no good way to apply a marker to a specific combination of parameter and test method. That means we've been applying the `xfail` marker to entire projects, meaning that all the test methods for, say, `pytest` would be marked as expected failures even if they actually pass.

This PR changes that by implementing a new marker, `distribute`, which takes a dict mapping test names to "sub-markers" and applies each sub-marker to only tests with that name, within the scope where `distribute` is used. It allows us to use `distribute` on a specific external project (like `pytest`) and specify exactly which individual test methods are supposed to fail for that project.

This gets us a few benefits:

- Once I started using the new marker, I realized that `test_readme` for `pytest-localserver` was actually failing, even though it was supposed to be fixed by #156. That failure was previously masked because all pytest-localserver tests were marked as xfail.
- We can now annotate each xfailing test method with an issue number. I've done that as part of this PR, where issues exist.
- Perhaps most importantly, I'm now turning on strict mode for xfail, and so any time we fix one of the xfailing tests, we'll be reminded to remove the marker and (if applicable) close the corresponding issue.