### PR TITLE
Add testing with Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,9 @@ jobs:
         - python: "3.6"
           platform: ubuntu-20.04
           force-minimum-dependencies: false
+        - python: "3.13"
+          platform: ubuntu-latest
+          force-minimum-dependencies: false
         # For testing forced minimum deps, use the latest stable version of Python
         # on which those dependencies can be installed
         - python: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
         - python: "3.11"
           platform: ubuntu-latest
           force-minimum-dependencies: false
+        - python: "3.13"
+          platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: pypy3.6
           platform: ubuntu-latest
           force-minimum-dependencies: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ env:
 jobs:
   test:
     runs-on: ${{ inputs.platform }}
+    continue-on-error: ${{ inputs.python-version >= '3.13' }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python


### PR DESCRIPTION
The final beta of Python 3.13 is now available, so I'm adding it to the list of versions we test. It's not required to pass for now since 3.13 is not final.