### PR TITLE
Add explicit coverage.py configuration

### DIFF
--- a/changelog.d/+coverage-config.misc.rst
+++ b/changelog.d/+coverage-config.misc.rst
@@ -1,0 +1,1 @@
+Add a coverage.py configuration to select which files are measured and enable branch coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,7 @@ src = ["src"]
 target-version = "py36"
 
 [tool.setuptools_scm]
+
+[tool.coverage.run]
+branch = true
+source_pkgs = ["setuptools_pyproject_migration", "test_support"]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ deps =
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
 commands =
-	pytest {posargs}
+	pytest --cov --cov-config=pyproject.toml {posargs}
 usedevelop = True
 extras =
 	testing


### PR DESCRIPTION
This pull request adds a coverage.py configuration which enables branch coverage and limits coverage reporting to files in the package itself. Previously, there was nothing telling coverage.py not to measure coverage for files generated during testing, so it would pollute the output with meaningless coverage numbers for a bunch of temporary files.
    
I put the configuration in `pyproject.toml` rather than any of the other configuration files coverage.py supports because TOML is a better specified format than INI.

I also edited the `pytest` command run from tox to ensure that it will use `pyproject.toml` as the coverage.py configuration file.
