### PR TITLE
Enable tox output in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,6 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 'true'
   PIP_NO_WARN_SCRIPT_LOCATION: 'true'
 
-  # Disable the spinner, noise in GHA; TODO(webknjaz): Fix this upstream
-  # Must be "1".
-  TOX_PARALLEL_NO_SPINNER: 1
-
 
 jobs:
   test:


### PR DESCRIPTION
It looks like setting `TOX_PARALLEL_NO_SPINNER` to 1 completely disables all output from tox and the commands it runs, except for the final message that an environment ran successfully. So I'm removing that variable from our CI configuration. We want the full output to appear in CI.