### PR TITLE
Parse dependencies with no markers from core metadata

### DIFF
--- a/changelog.d/133.bugfix.rst
+++ b/changelog.d/133.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in test support code where it wouldn't parse dependencies without markers from a package's core metadata

--- a/test_support/test_support/metadata.py
+++ b/test_support/test_support/metadata.py
@@ -2,6 +2,7 @@
 Code for manipulating core metadata
 """
 
+import logging
 import packaging.specifiers
 import packaging.version
 import re
@@ -39,6 +40,9 @@ except ImportError:
 
     class StandardMetadata:  # type: ignore[no-redef]
         pass
+
+
+_logger = logging.getLogger("setuptools_pyproject_migration:test_support:" + __name__)
 
 
 def _parse_contributors(
@@ -199,17 +203,20 @@ def parse_core_metadata(message: Union[RFC822Message, importlib_metadata.Package
             optional_dependencies = defaultdict(list)
 
         for dist in get("Requires-Dist"):
+            _logger.debug("Handling Requires-Dist: %s", dist)
             req = packaging.requirements.Requirement(dist)
             if req.marker:
                 m = _extra_pattern.search(str(req.marker))
                 if m:
                     _extra_name = m.group("extra")
                     assert _extra_name
+                    _logger.debug("Adding optional dependency %r with extra %s", req, _extra_name)
                     try:
                         optional_dependencies[_extra_name].append(req)
                     except KeyError:
                         raise ValueError(f"Unknown extra {_extra_name}")
                 else:
+                    _logger.debug("Adding dependency %r (marker is not an extra)", req)
                     dependencies.append(req)
         if isinstance(optional_dependencies, defaultdict):
             optional_dependencies = dict(optional_dependencies)

--- a/test_support/test_support/metadata.py
+++ b/test_support/test_support/metadata.py
@@ -218,6 +218,9 @@ def parse_core_metadata(message: Union[RFC822Message, importlib_metadata.Package
                 else:
                     _logger.debug("Adding dependency %r (marker is not an extra)", req)
                     dependencies.append(req)
+            else:
+                _logger.debug("Adding dependency %r (no marker)", req)
+                dependencies.append(req)
         if isinstance(optional_dependencies, defaultdict):
             optional_dependencies = dict(optional_dependencies)
     elif is_at_least("1.1") and has("Requires"):

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -66,7 +66,6 @@ distributions: List = [
         marks=[
             pytest.mark.distribute(
                 {
-                    "test_dependencies": pytest.mark.xfail(reason="Issue #133"),
                     "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
                     "test_authors": pytest.mark.xfail(reason="Issue #135"),
                     "test_keywords": pytest.mark.xfail(reason="Issue #136"),
@@ -80,7 +79,6 @@ distributions: List = [
         marks=pytest.mark.distribute(
             {
                 "test_readme": pytest.mark.xfail,
-                "test_dependencies": pytest.mark.xfail(reason="Issue #135"),
                 "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
             }
         ),


### PR DESCRIPTION
In our test support code that parses the core metadata of a package, it turns out I had totally forgotten to parse dependencies which do not have any markers. This PR adds a branch to do that and updates the expected test results accordingly. I also added some logging messages which were helpful in diagnosing the problem.
