### PR TITLE
Split keywords in test support code

### DIFF
--- a/changelog.d/136.bugfix.rst
+++ b/changelog.d/136.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in test support code where it was not splitting lists of keywords from core metadata


### PR DESCRIPTION
Even though the core metadata allows multiple Keywords headers, in practice all a package's keywords seem to be combined into one header joined by commas, or maybe spaces for some older packages. This commit changes the test support code that parses core metadata to account for that by splitting the Keywords header (if single-valued). The delimiter is chosen based on the metadata version: in core metadata version 1.x, it allows spaces as a separator, but in version 2.x, it only allows commas.

Closes #136