### PR TITLE
Enable slow tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       python-version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}
       force-minimum-dependencies: ${{ matrix.force-minimum-dependencies }}
-      run-slow: ${{ inputs.run-slow || false }}
+      run-slow: ${{ inputs.run-slow || true }}
   docs:
     name: Build documentation
     uses: ./.github/workflows/docs.yml

--- a/changelog.d/+slow-tests.misc.rst
+++ b/changelog.d/+slow-tests.misc.rst
@@ -1,0 +1,1 @@
+Run slow tests during CI

--- a/test_support/test_support/metadata.py
+++ b/test_support/test_support/metadata.py
@@ -187,7 +187,7 @@ def parse_core_metadata(message: Union[RFC822Message, importlib_metadata.Package
     # non-compliant to use spaces in this field, but v2 of the spec seems like as
     # good a guess as any. If we find real-world examples of packages with v2 core
     # metadata that are using space-separated keywords, we can adjust this accordingly.
-    raw_keywords: List[str] = get("Keywords", [""])
+    raw_keywords: List[str] = get("Keywords", [])
     _logger.debug("Handling Keywords: %r", raw_keywords)
     if len(raw_keywords) == 1:
         if is_at_least("2.0"):

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -68,7 +68,6 @@ distributions: List = [
                 {
                     "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
                     "test_authors": pytest.mark.xfail(reason="Issue #135"),
-                    "test_keywords": pytest.mark.xfail(reason="Issue #136"),
                 }
             ),
             pytest.mark.skipif(_setuptools_scm_version_conflict(), reason="Issue #145"),

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -94,6 +94,7 @@ version = "0.0.1"
 # This next test should be kept up to date as we add support for more fields.
 
 
+@pytest.mark.slow
 def test_everything(project, runner, console_script_project_runner: ProjectRunner) -> None:
     """
     Test all fields that the project supports.


### PR DESCRIPTION
I made a couple mistakes in #166 that were causing our full test suite to fail, but we didn't notice because the distribution package tests were not being run during CI. This PR fixes that.