### PR TITLE
Relax the check of optional dependencies to allow missing extras

### DIFF
--- a/changelog.d/134.bugfix.rst
+++ b/changelog.d/134.bugfix.rst
@@ -1,0 +1,1 @@
+Relax matching of optional dependency requirements to allow for a missing extra condition in the marker

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -72,7 +72,6 @@ distributions: List = [
         marks=[
             pytest.mark.distribute(
                 {
-                    "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
                     "test_authors": pytest.mark.xfail(reason="Issue #135"),
                 }
             ),
@@ -84,7 +83,6 @@ distributions: List = [
         marks=pytest.mark.distribute(
             {
                 "test_readme": pytest.mark.xfail,
-                "test_optional_dependencies": pytest.mark.xfail(reason="Issue #134"),
             }
         ),
     ),


### PR DESCRIPTION
We've had failures in the distribution package tests because the expected optional dependencies (parsed from the packages' core metadata by our test support code) include markers for the extras, but the actual optional dependencies (generated by `setuptools_pyproject_migration` itself) don't. This commit addresses those failures by effectively trying to ignore the part of the marker expression that specifies an extra and comparing the rest.

The most robust way to fix this would have been to add some code that parses the markers into a tree and manipulates the tree to add or remove the extra marker. But parsing markers is pretty complicated; the `packaging` package includes some code to do it, but it takes up two [whole](https://github.com/pypa/packaging/blob/main/src/packaging/_parser.py) [modules](https://github.com/pypa/packaging/blob/main/src/packaging/_tokenizer.py), and it's not part of their public API so we shouldn't really use it. And we'd still need to do some tree manipulation even after parsing, which would probably involve adding some reasonably complex code to the test support package.
                                                                                                                                                                                                                                                     
Instead, what I've done here is to put some heuristics in the test for optional dependencies which will recognize common patterns by which the expected and actual markers might differ. Specifically, any of these will not cause the test to fail:

- The expected and actual markers are equal (this was the status quo)
- The actual marker is unset and the expected marker only has one condition, which is the extra
- The expected marker is "{actual marker} and extra == {extra}", with parenthesis if needed to enforce precedence; this is nearly the same [pattern used by pyproject-metadata to convert its optional dependency Requirements into RFC822 headers](https://github.com/pypa/pyproject-metadata/blob/main/pyproject_metadata/__init__.py#L372-L382) (although the version I added is not entirely careful about checking for nested parentheses in the actual marker, so it could get confused, but we can fix that if it comes up)

With these heuristics, we can get our optional dependency tests to pass, which as far as I'm concerned is good enough to go forward with.

Closes #134 