### PR TITLE
Handle email addresses in StandardMetadata which are None

### DIFF
--- a/changelog.d/135.bugfix.rst
+++ b/changelog.d/135.bugfix.rst
@@ -1,0 +1,1 @@
+Work around pyproject-metadata producing None for author/maintainer email addresses

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -69,14 +69,7 @@ distributions: List = [
     # PyPiDistribution(name, version)
     pytest.param(
         PyPiDistribution("pytest", "7.3.0"),
-        marks=[
-            pytest.mark.distribute(
-                {
-                    "test_authors": pytest.mark.xfail(reason="Issue #135"),
-                }
-            ),
-            pytest.mark.skipif(_setuptools_scm_version_conflict(), reason="Issue #145"),
-        ],
+        marks=pytest.mark.skipif(_setuptools_scm_version_conflict(), reason="Issue #145"),
     ),
     pytest.param(
         PyPiDistribution("pytest-localserver", "0.8.0"),


### PR DESCRIPTION
pyproject-metadata's `StandardMetadata.from_pyproject()` method has an apparent bug where, if it is handling author or maintainer metadata that specifies a name but no email address, it uses `None` to represent the email address even though the declared type of the field is `str`. I [reported this upstream](https://github.com/pypa/pyproject-metadata/issues/126) but there's been no activity on the report so far. So, until that changes, I'm adding code to work around that bug by replacing `None` in the email address field with an empty string.

This allows all our pytest distribution package tests to pass so I've removed the last xfail marker from that test class accordingly.