### PR TITLE
Exclude some irrelevant config files from sdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ install_requires =
 
 [options.packages.find]
 exclude =
+    .github/
+    .readthedocs.yaml
 	build*
 	dist*
 	docs*


### PR DESCRIPTION
This change excludes the configuration files for GitHub (Actions and dependabot) and ReadTheDocs from an sdist. Those configuration files are only relevant to people working with the GitHub project, not to anyone who just has a snapshot of the source code. This is just to keep the sdist clean and focused on being a Python package with source code and tests.