### PR TITLE
Exclude Python 3.6 on Mac OS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,11 @@ jobs:
         force-minimum-dependencies:
         - false
         exclude:
-        # Python 3.6 does not run on ubuntu-latest
+        # Python 3.6 does not run on ubuntu-latest or any version of macos
         - python: "3.6"
           platform: ubuntu-latest
+        - python: "3.6"
+          platform: macos-latest
         include:
         - python: "3.6"
           platform: ubuntu-20.04


### PR DESCRIPTION
GitHub Actions no longer supports Python 3.6 on any version of Mac OS, so we can exclude that from the matrix of tests.

This fixes one of the job failures that came up while testing v0.3.