### PR TITLE
Handle "optional" dependencies with no extra

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,11 @@ jobs:
         - python: "3.13"
           platform: ubuntu-latest
           force-minimum-dependencies: false
-        # For testing forced minimum deps, use the latest stable version of Python
-        # on which those dependencies can be installed
+        # For testing forced minimum deps, use the newest and oldest stable
+        # versions of Python on which those dependencies can be installed.
+        - python: "3.8"
+          platform: ubuntu-latest
+          force-minimum-dependencies: true
         - python: "3.12"
           platform: ubuntu-latest
           force-minimum-dependencies: true

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -24,7 +24,6 @@ import logging
 import packaging.markers
 import packaging.requirements
 import pytest
-import sys
 
 from typing import Iterator, List
 
@@ -51,8 +50,6 @@ def _setuptools_scm_version_conflict() -> bool:
     See `issue 145 <https://github.com/diazona/setuptools-pyproject-migration/issues/145>`_.
     """
 
-    if sys.version_info < (3, 12):
-        return False
     from test_support import importlib_metadata
     from packaging.version import Version
 

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -205,3 +205,18 @@ def test_empty_extras(make_write_pyproject) -> None:
     cmd = make_write_pyproject(extras_require={})
     result = cmd._generate()
     assert "optional-dependencies" not in result["project"]
+
+
+def test_required_dependencies_with_constraints(make_write_pyproject) -> None:
+    """
+    Test that required dependencies with constraints are not added to the list
+    of optional dependencies.
+
+    This exercises a bug in setuptools<68.2 where required deps with constraints
+    get added to the list of optional dependencies with an empty extra.
+    """
+    dependencies: List[str] = ["holy-pin", 'holy-hand-grenade; python_version == "3.*"']
+    cmd = make_write_pyproject(install_requires=dependencies)
+    result = cmd._generate()
+    assert set(result["project"]["dependencies"]) == set(dependencies)
+    assert "optional-dependencies" not in result["project"]


### PR DESCRIPTION
Versions of setuptools prior to 68.2 have an issue where they will misrepresent dependencies that have a constraint but no extra as optional dependencies with an empty extra string. For example, if a `setup.cfg` file includes this:

```cfg
[options]
install_requires =
  importlib-metadata>=0.12;python_version<"3.8"
```
    
that dependency should be parsed as a required dependency on all Python versions less than 3.8, but these old versions of setuptools parse it as if it were this instead:

```cfg
[options.extras_require]
=
  importlib-metadata>=0.12;python_version<"3.8"
```

(with an empty key under options.extras_require). This causes test failures on older versions of Python or anywhere else we have an old version of setuptools to work with.

To address this, in this PR I'm changing the logic that parses dependencies and optional dependencies so it adds anything associated with an empty extra to the set of required dependencies. I also added some logging statements that were helpful in diagnosing this error.

Additionally, I added a test (not a distribution package test) that reproduces the error when run with `setuptools<68.2`, and I changed the pre-/post-merge testing workflow to run tests with old versions of our dependencies on Python 3.8, in addition to Python 3.12 which we were already doing. This should give us a better chance at catching issues like this in the future.

Closes #175 
