### PR TITLE
Configure pytest to use importlib import mode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs=dist build .tox .eggs
-addopts=-v --doctest-modules
+addopts=-v --doctest-modules --import-mode=importlib
 filterwarnings=
 	## upstream
 


### PR DESCRIPTION
pytest recommends using the importlib import mode for new projects to avoid test name conflicts, as described [in the documentation](https://docs.pytest.org/en/latest/explanation/goodpractices.html#which-import-mode). Our test files all have different names, so this hasn't been an issue, but it's still a good idea to use the recommended practice. So I'm changing the pytest configuration to do so.