### PR TITLE
Generate changelog for version 0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,27 @@
+0.3
+===
+
+Bugfixes
+--------
+
+- Add more robust handling of long descriptions and their content types (#132)
+- Fix a bug in test support code where it wouldn't parse dependencies without markers from a package's core metadata (#133)
+- Relax matching of optional dependency requirements to allow for a missing extra condition in the marker (#134)
+- Work around pyproject-metadata producing None for author/maintainer email addresses (#135)
+- Fix a bug in test support code where it was not splitting lists of keywords from core metadata (#136)
+- Handle INI-style ``entry_point`` strings. (#152)
+
+
+Misc
+----
+
+- #109
+- Add a coverage.py configuration to select which files are measured and enable branch coverage
+- Apply xfail markers to individual test methods in external project tests and enable xfail_strict
+- Mark project as active
+- Run slow tests during CI
+
+
 0.2
 ===
 

--- a/changelog.d/+active.misc.rst
+++ b/changelog.d/+active.misc.rst
@@ -1,1 +1,0 @@
-Mark project as active

--- a/changelog.d/+coverage-config.misc.rst
+++ b/changelog.d/+coverage-config.misc.rst
@@ -1,1 +1,0 @@
-Add a coverage.py configuration to select which files are measured and enable branch coverage

--- a/changelog.d/+distribute.misc.rst
+++ b/changelog.d/+distribute.misc.rst
@@ -1,1 +1,0 @@
-Apply xfail markers to individual test methods in external project tests and enable xfail_strict

--- a/changelog.d/+slow-tests.misc.rst
+++ b/changelog.d/+slow-tests.misc.rst
@@ -1,1 +1,0 @@
-Run slow tests during CI

--- a/changelog.d/109.misc.rst
+++ b/changelog.d/109.misc.rst
@@ -1,1 +1,0 @@
-Reduce pre-commit.ci autoupdate frequency to monthly

--- a/changelog.d/132.bugfix.rst
+++ b/changelog.d/132.bugfix.rst
@@ -1,1 +1,0 @@
-Add more robust handling of long descriptions and their content types

--- a/changelog.d/133.bugfix.rst
+++ b/changelog.d/133.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a bug in test support code where it wouldn't parse dependencies without markers from a package's core metadata

--- a/changelog.d/134.bugfix.rst
+++ b/changelog.d/134.bugfix.rst
@@ -1,1 +1,0 @@
-Relax matching of optional dependency requirements to allow for a missing extra condition in the marker

--- a/changelog.d/135.bugfix.rst
+++ b/changelog.d/135.bugfix.rst
@@ -1,1 +1,0 @@
-Work around pyproject-metadata producing None for author/maintainer email addresses

--- a/changelog.d/136.bugfix.rst
+++ b/changelog.d/136.bugfix.rst
@@ -1,1 +1,0 @@
-Fix a bug in test support code where it was not splitting lists of keywords from core metadata

--- a/changelog.d/152.bugfix.rst
+++ b/changelog.d/152.bugfix.rst
@@ -1,1 +1,0 @@
-Handle INI-style ``entry_point`` strings.


### PR DESCRIPTION
This was done by running `tox -e towncrier -- --version 0.3`.

I've generated the changelog for version 0.3 even though this commit is based on v0.3.1 because the changes made between those two versions didn't have a changelog fragment anyway (they should, but I forgot), and ensuring eventual consistency of the changelog is more important than getting the changelog entries in the right release. Ultimately I just don't think it's important enough to make it worth doing the technically proper thing of making post-releases for both v0.3 and v0.3.1.

My plan is to release v0.3.1.post0 based on this branch _without_ merging in the changes made on `main` after the release of v0.3.1. That way the packages we push to PyPI will look approximately right: the only difference between v0.3.1 and v0.3.1.post0 will be the changelog update.