### PR TITLE
Fix parsing of wheel version numbers

### DIFF
--- a/changelog.d/+wheel-parsing-prerelease-versions.bugfix.rst
+++ b/changelog.d/+wheel-parsing-prerelease-versions.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where parsing of wheel filenames in test support code would miss prerelease version numbers

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ testing =
 		python_version < "3.8"
 	importlib-metadata; \
 		python_version < "3.8"
+	wheel-filename
 	# no version of pyproject-metadata supports Python 3.6
 	# pyproject-metadata 0.9.0 has breaking changes vs 0.8.1 and earlier.
 	pyproject-metadata >= 0.9.0; \

--- a/test_support/test_support/metadata.py
+++ b/test_support/test_support/metadata.py
@@ -205,7 +205,7 @@ def parse_core_metadata(message: Union[RFC822Message, importlib_metadata.Package
             urls[_label.strip()] = _url.strip()
 
     dependencies: List[packaging.requirements.Requirement] = []
-    optional_dependencies: Dict[str, List[packaging.requirements.Requirement]]
+    optional_dependencies: Dict[str, List[packaging.requirements.Requirement]] = {}
 
     if is_at_least("1.2") and has("Requires-Dist"):
         if is_at_least("2.1"):

--- a/test_support/test_support/package_filename.py
+++ b/test_support/test_support/package_filename.py
@@ -1,0 +1,104 @@
+import logging
+import packaging.version
+import re
+
+from typing import NamedTuple, Union
+from wheel_filename import ParsedWheelFilename, parse_wheel_filename
+
+
+_logger = logging.getLogger("test_support.package_filename")
+
+
+def normalize_package_name(name: str):
+    """
+    Normalize a Python package name in the manner specified by :pep:`503`.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+class ParsedSdistFilename(NamedTuple):
+    """
+    A simple representation of the filename of an sdist. This is modeled after
+    :py:class:`wheel_filename.ParsedWheelFilename`.
+
+    This needs to represent both standard (:pep:`625`-compliant) and nonstandard
+    filenames.
+    """
+
+    project: str
+    """
+    The distribution name of the project. This is the name it would be listed
+    under on PyPI.
+    """
+
+    version: str
+    """
+    The version of the project.
+
+    For compatibility with :py:class:`wheel_filename.ParsedWheelFilename`, this
+    will be a string, but under all but the most unusual circumstances it's
+    guaranteed to be a valid :pep:`440` version string which can be passed to
+    :py:func:`packaging.version.parse()`. The only exception is if an sdist has
+    an extremely nonstandard filename from which it wasn't possible to extract
+    a :pep:`440`-compliant version, this may be set to a best guess at
+    the package's version.
+    """
+
+    def __str__(self) -> str:
+        return f"{self.project}-{self.version!s}.tar.gz"
+
+
+def parse_package_filename(filename: str) -> Union[ParsedSdistFilename, ParsedWheelFilename]:
+    """
+    Parse a filename of a Python package, either sdist or wheel.
+
+    >>> parse_package_filename("project-0.1.tar.gz")
+    ParsedSdistFilename(project='project', version='0.1')
+    >>> parse_package_filename("project-0.1-py3-none-any.whl")
+    ParsedWheelFilename(project='project', version='0.1', build=None, python_tags=['py3'], abi_tags=['none'], platform_tags=['any'])
+
+    This will handle nonstandard sdist filenames as well, as long as they're
+    not too crazy.
+
+    >>> parse_package_filename("project-name-0.1-post0.tar.gz")
+    ParsedSdistFilename(project='project-name', version='0.1-post0')
+    """  # noqa: E501
+    if filename.endswith(".whl"):
+        return parse_wheel_filename(filename)
+    elif filename.endswith(".tar.gz"):
+        basename = filename[:-7]
+        # PEP 625 specifies that "-" should not occur in the package name portion
+        # of a filename, so we should be able to split on the first hyphen.
+        name, _, version = basename.partition("-")
+        try:
+            packaging.version.parse(version)
+        except packaging.version.InvalidVersion:
+            # But to support testing of nonstandard sdist filenames, we need to
+            # handle cases where the separator between the name and version
+            # is not the first hyphen.
+            _logger.debug("Parsing nonstandard version %s", version)
+        else:
+            return ParsedSdistFilename(name, version)
+
+        # Loop over subsequent hyphens and find the first one that we can split
+        # on and have the second portion of the string be a valid version.
+        try:
+            while True:
+                split_point = basename.index("-", len(name) + 1)
+                assert split_point > len(name)
+                name = basename[:split_point]
+                assert len(name) == split_point
+                version = basename[split_point + 1 :]
+                try:
+                    packaging.version.parse(version)
+                except packaging.version.InvalidVersion:
+                    _logger.debug("Failed to parse as name %s and version %s", name, version)
+                else:
+                    return ParsedSdistFilename(name, version)
+        except IndexError:
+            # We could not produce a valid version by splitting on any hyphen.
+            # For now, just continue on to raise an error. If we need to support
+            # this case, a good heuristic might be to find the first hyphen
+            # which is immediately followed by a number and split on that.
+            _logger.warning("Failed to parse sdist filename %s", filename)
+    raise ValueError(f"Not a valid Python package filename: {filename}")

--- a/tests/test_filename_matching.py
+++ b/tests/test_filename_matching.py
@@ -1,0 +1,91 @@
+"""
+Tests that verify the logic we use to match sdist and wheel filenames is
+consistent with the packaging standards.
+"""
+
+import packaging.version
+import pytest
+
+from test_support.package_filename import ParsedSdistFilename, parse_package_filename
+from typing import List, Optional, Tuple
+from wheel_filename import ParsedWheelFilename
+
+SDIST: List[Tuple[str, str]] = [
+    ("p", "1.0"),
+    ("package", "1.0"),
+    ("package_name", "1.0"),
+    ("package", "0.1"),
+    ("package", "0.0.1"),
+    ("package", "0.0.100"),
+    ("package", "1.post0"),
+    ("package", "0.0.1.post0"),
+    ("package", "2024.09.06"),
+    ("package", "20240906"),
+    ("package", "1a"),
+    ("package", "1a0"),
+    ("package", "1a1"),
+    ("package", "1a10"),
+    ("package", "1b"),
+    ("package", "1b0"),
+    ("package", "1b1"),
+    ("package", "1rc"),
+    ("package", "1rc0"),
+    ("package", "1rc1"),
+]
+
+# PEP 625 specifies that the project name in an sdist filename should be
+# normalized in the same way as with a wheel filename, but some older
+# packages do not follow this standard
+NONSTANDARD_SDIST: List[Tuple[str, str]] = [
+    ("package-name", "1.0"),
+]
+
+
+@pytest.mark.parametrize(("name", "version"), SDIST + NONSTANDARD_SDIST)
+class TestSDistFilename:
+    @pytest.fixture
+    def match_filename(self, name: str, version: str) -> ParsedSdistFilename:
+        filename = f"{name}-{version}.tar.gz"
+        parsed = parse_package_filename(filename)
+        assert isinstance(parsed, ParsedSdistFilename)
+        return parsed
+
+    def test_project(self, name: str, version: str, match_filename: ParsedSdistFilename) -> None:
+        assert match_filename.project == name
+
+    def test_version(self, name: str, version: str, match_filename: ParsedSdistFilename) -> None:
+        assert packaging.version.parse(match_filename.version) == packaging.version.parse(version)
+
+
+WHEEL_TAGS: List[Tuple[Optional[str], str, str, str]] = [
+    (None, "py3", "none", "any"),
+    ("1", "py3", "none", "any"),
+    (None, "py38", "cp38", "any"),
+    (None, "py3", "none", "linux_86_64"),
+]
+
+
+@pytest.mark.parametrize(("name", "version"), SDIST)
+@pytest.mark.parametrize(("build", "python", "abi", "platform"), WHEEL_TAGS)
+class TestWheelFilename:
+    @pytest.fixture
+    def match_filename(
+        self, name: str, version: str, build: str, python: str, abi: str, platform: str
+    ) -> ParsedWheelFilename:
+        filename = f"{name}-{version}"
+        if build:
+            filename += f"-{build}"
+        filename += f"-{python}-{abi}-{platform}.whl"
+        parsed = parse_package_filename(filename)
+        assert isinstance(parsed, ParsedWheelFilename)
+        return parsed
+
+    def test_name(
+        self, name: str, version: str, python: str, abi: str, platform: str, match_filename: ParsedWheelFilename
+    ) -> None:
+        assert match_filename.project == name
+
+    def test_version(
+        self, name: str, version: str, python: str, abi: str, platform: str, match_filename: ParsedWheelFilename
+    ) -> None:
+        assert packaging.version.parse(match_filename.version) == packaging.version.parse(version)


### PR DESCRIPTION
In our test support code we have a function that parses sdist and wheel filenames, but it turns out that function had a bug that caused it to miss the number in the prerelease component of a wheel filename. To fix that, I replaced the wheel filename parser with the [wheel-filename](https://github.com/wheelodex/wheel-filename) package, and reduced our custom code to just parsing sdist filenames, which is much easier. I also added tests of the new parsing function.

I discovered this while adding the [extrainterpreters](https://github.com/jsbueno/extrainterpreters) package as a distribution package test case.