### PR TITLE
Fix build issues detected by newer tools

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
+      - name: Set up venv
+        run: python -m venv .pyenv
       - name: Install tox
-        run: python -m pip install tox
-      - name: Run
-        run: tox -e docs
+        run: .pyenv/bin/python -m pip install tox
+      - name: Run tox
+        run: .pyenv/bin/python -m tox -e docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   - id: mypy
     exclude: "conftest\\.py$"
     additional_dependencies:
-    - pyproject-metadata
+    - pyproject-metadata >= 0.9.0
     - setuptools
     - types-requests
 

--- a/changelog.d/185.bugfix.rst
+++ b/changelog.d/185.bugfix.rst
@@ -1,0 +1,1 @@
+Bump the minimum version of ``pyproject_metadata`` to release ``0.9.0`` as this release has breaking changes compared to ``0.8.1`` and earlier.

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ testing =
 	importlib-metadata; \
 		python_version < "3.8"
 	# no version of pyproject-metadata supports Python 3.6
-	pyproject-metadata; \
+	pyproject-metadata >= 0.8.1; \
 		python_version >= "3.7"
 	requests
 	types-setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,8 @@ testing =
 	importlib-metadata; \
 		python_version < "3.8"
 	# no version of pyproject-metadata supports Python 3.6
-	pyproject-metadata >= 0.8.1; \
+	# pyproject-metadata 0.9.0 has breaking changes vs 0.8.1 and earlier.
+	pyproject-metadata >= 0.9.0; \
 		python_version >= "3.7"
 	requests
 	types-setuptools

--- a/test_support/test_support/distribution.py
+++ b/test_support/test_support/distribution.py
@@ -473,7 +473,7 @@ class PyPiPackagePreparation(DistributionPackagePreparation):
             message[key] = value.strip()
         body: str = raw_metadata.read()
         if body:
-            message.body = body
+            message.set_payload(body)
         return message
 
     @cached_property


### PR DESCRIPTION
Changes in dependencies and test tools triggered a build failure in the `main` branch regarding the `Metadata` data type.

Furthermore, a stricter `pip` caused issues with doing documentation builds.

This corrects both issues: test-merged with #184 in `nomerge/metadata-and-precommit-changes` to confirm bugfix.