### PR TITLE
.readthedocs.yaml: Fix build issue with docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,8 @@ build:
     - 'git fetch --unshallow --tags || true'
     pre_install:
     - git update-index --assume-unchanged docs/conf.py
+
+# https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,6 @@ build:
     pre_install:
     - git update-index --assume-unchanged docs/conf.py
 
-# https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
 sphinx:
   # Path to your Sphinx configuration file.
   configuration: docs/conf.py


### PR DESCRIPTION
Apparently ReadTheDocs now require you to explicitly label where the configuration file is for `sphinx` to build documentation.

https://readthedocs.org/projects/setuptools-pyproject-migration/builds/27476946/
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

I tested this on the branch for PR#188, but have cherry-picked it here for clarity.