### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,8 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.6"
-        - "3.8"
-        - "3.12"
+        - "3.9"
+        - "3.13"
         platform:
         # This package is supposed to be OS-independent and is unlikely to have
         # OS-specific bugs, so we conserve runner usage by only testing on Linux
@@ -37,23 +36,16 @@ jobs:
         - ubuntu-latest
         force-minimum-dependencies:
         - false
-        exclude:
-        # Python 3.6 does not run on ubuntu-latest
-        - python: "3.6"
-          platform: ubuntu-latest
         include:
-        - python: "3.6"
-          platform: ubuntu-20.04
-          force-minimum-dependencies: false
-        - python: "3.13"
-          platform: ubuntu-latest
+        - python: "3.7"
+          platform: ubuntu-22.04
           force-minimum-dependencies: false
         # For testing forced minimum deps, use the newest and oldest stable
         # versions of Python on which those dependencies can be installed.
-        - python: "3.8"
-          platform: ubuntu-latest
+        - python: "3.7"
+          platform: ubuntu-22.04
           force-minimum-dependencies: true
-        - python: "3.12"
+        - python: "3.13"
           platform: ubuntu-latest
           force-minimum-dependencies: true
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,29 +28,19 @@ jobs:
         # Of course if we ever do find such bugs, we should add additional
         # matrix entries as necessary to ensure they are properly tested for.
         python:
-        - "3.6"
-        - "3.8"
-        - "3.12"
+        - "3.9"
+        - "3.13"
         platform:
         - ubuntu-latest
         - macos-latest
         - windows-latest
         force-minimum-dependencies:
         - false
-        exclude:
-        # Python 3.6 does not run on ubuntu-latest or any version of macos
-        - python: "3.6"
-          platform: ubuntu-latest
-        - python: "3.6"
-          platform: macos-latest
         include:
-        - python: "3.6"
-          platform: ubuntu-20.04
-          force-minimum-dependencies: false
         - python: "3.7"
-          platform: ubuntu-latest
+          platform: ubuntu-22.04
           force-minimum-dependencies: false
-        - python: "3.9"
+        - python: "3.8"
           platform: ubuntu-latest
           force-minimum-dependencies: false
         - python: "3.10"
@@ -59,10 +49,7 @@ jobs:
         - python: "3.11"
           platform: ubuntu-latest
           force-minimum-dependencies: false
-        - python: "3.13"
-          platform: ubuntu-latest
-          force-minimum-dependencies: false
-        - python: pypy3.6
+        - python: "3.12"
           platform: ubuntu-latest
           force-minimum-dependencies: false
         - python: pypy3.7
@@ -77,10 +64,10 @@ jobs:
         # For testing forced minimum deps, use both the earliest and latest stable
         # (non-dev) versions of Python on which this package and the pinned
         # dependencies can be installed
-        - python: "3.6"
-          platform: ubuntu-20.04
+        - python: "3.7"
+          platform: ubuntu-22.04
           force-minimum-dependencies: true
-        - python: "3.12"
+        - python: "3.13"
           platform: ubuntu-latest
           force-minimum-dependencies: true
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,14 +85,14 @@ jobs:
     - test
     - docs
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
     - name: Install pypa/build
       run: python -m pip install --user build
     - name: Build packages
       run: python -m build
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/
@@ -109,7 +109,7 @@ jobs:
       # this permission is mandatory for trusted publishing
       id-token: write
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist/
@@ -131,7 +131,7 @@ jobs:
       # this permission is mandatory for trusted publishing
       id-token: write
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,15 +15,12 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # v0.0.233: Last version of ruff which will accept "py36" as target-version
-  rev: v0.0.233
+  rev: v0.11.8
   hooks:
   - id: ruff
     args:
     - "--fix"
-    # When updating to ruff v0.0.244 or higher, this can be enabled to improve
-    # change detection by pre-commit
-    #- "--exit-non-zero-on-fix"
+    - "--exit-non-zero-on-fix"
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ src = ["src"]
 # Ruff is capable of inferring this from project.requires-python, but we don't
 # set that because we keep our project configuration in setup.cfg, so list it
 # explicitly here.
-target-version = "py36"
+target-version = "py37"
 
 [tool.setuptools_scm]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,8 @@ packages = find:
 package_dir =
 	= src
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
-	dataclasses; python_version < "3.7"
 	packaging
 	pep508-parser
 	setuptools; python_version < "3.12"
@@ -61,10 +60,8 @@ testing =
 	importlib-metadata; \
 		python_version < "3.8"
 	wheel-filename
-	# no version of pyproject-metadata supports Python 3.6
 	# pyproject-metadata 0.9.0 has breaking changes vs 0.8.1 and earlier.
-	pyproject-metadata >= 0.9.0; \
-		python_version >= "3.7"
+	pyproject-metadata >= 0.9.0
 	requests
 	types-setuptools
 

--- a/test_support/test_support/distribution.py
+++ b/test_support/test_support/distribution.py
@@ -26,25 +26,11 @@ import urllib.parse
 import warnings
 
 from abc import ABC, abstractmethod
+from pyproject_metadata import RFC822Message, StandardMetadata
 from test_support import importlib_metadata, Project
 from test_support.package_filename import normalize_package_name, parse_package_filename
 from test_support.metadata import parse_core_metadata
 from typing import Any, IO, Iterable, List, Optional, Sequence
-
-try:
-    from pyproject_metadata import RFC822Message, StandardMetadata
-except ImportError:
-    # pyproject-metadata is not available for Python <3.7. That's okay because
-    # we skip all the tests that would use RFC822Message if pyproject-metadata
-    # is not available, so that name doesn't need to have a definition that is
-    # valid at runtime, but pytest still scans this file looking for doctests
-    # so it still needs to be importable. As long as this name is defined as
-    # _something_ which is a valid type, that will be the case.
-    class RFC822Message:  # type: ignore[no-redef]
-        pass
-
-    class StandardMetadata:  # type: ignore[no-redef]
-        pass
 
 
 try:

--- a/tests/distribution/test_distribution_packages.py
+++ b/tests/distribution/test_distribution_packages.py
@@ -25,15 +25,10 @@ import packaging.markers
 import packaging.requirements
 import pytest
 
+from pyproject_metadata import StandardMetadata
 from typing import Iterator, List
 
-# Try importing pyproject_metadata but don't save the module itself because we don't need it
-pytest.importorskip("pyproject_metadata")
-
-from pyproject_metadata import StandardMetadata  # noqa: E402
-
-# If pyproject_metadata isn't available, test_support.distribution won't be either
-from test_support.distribution import (  # noqa: E402
+from test_support.distribution import (
     DistributionPackage,
     DistributionPackagePreparation,
     PyPiDistribution,


### PR DESCRIPTION
GitHub has removed support for Ubuntu 20.04 runners, and the `setup-python` action no longer supports Python 3.6 on any of the more recent Ubuntu versions for which default runners are available, which means we can no longer test on Python 3.6 without setting up a custom runner environment or some such thing. I think that's enough work that it's no longer worth the effort to support Python 3.6. So in this pull request, I'm removing support for it.

The minimum Python version that this project supports will now be 3.7. (Which is still past EOL, so for anyone reading this, don't use it if you can help it.)