### PR TITLE
Allow manual release testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,16 @@
 name: Publish package to PyPI
+run-name: >
+  ${{
+    !(github.event_name == 'release' && github.event.action == 'published')
+    && 'Manual pre-release test'
+    || ''
+  }}
 
 on:
   release:
     types:
     - published
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -99,6 +106,7 @@ jobs:
         if-no-files-found: error
   publish-to-test-pypi:
     name: Publish packages to Test PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs:
     - test
@@ -120,6 +128,7 @@ jobs:
         print-hash: true
   publish-to-pypi:
     name: Publish packages to PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs:
     - test


### PR DESCRIPTION
In this commit I'm adding a workflow_dispatch trigger to the release workflow, which means at any time we can manually invoke the workflow to run a full suite of pre-release tests. I added conditions to the actual publish jobs so that manually invoked workflows will not attempt to upload to PyPI or Test PyPI, but they will do everything else. I also added the run-name entry in the YAML file to put a more descriptive name on manually triggered runs, so we don't get confused about which runs are actually publishing packages.