### PR TITLE
Add testing for Python 3.14

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,9 +39,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
       - name: Set up venv
         run: python -m venv .pyenv
       - name: Install tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
         - python: "3.7"
           platform: ubuntu-22.04
           force-minimum-dependencies: false
+        - python: "3.14"
+          platform: ubuntu-latest
+          force-minimum-dependencies: false
         # For testing forced minimum deps, use the newest and oldest stable
         # versions of Python on which those dependencies can be installed.
         - python: "3.7"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
         - python: "3.12"
           platform: ubuntu-latest
           force-minimum-dependencies: false
+        - python: "3.14"
+          platform: ubuntu-latest
+          force-minimum-dependencies: false
         - python: pypy3.7
           platform: ubuntu-latest
           force-minimum-dependencies: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,6 @@ env:
 jobs:
   test:
     runs-on: ${{ inputs.platform }}
-    continue-on-error: ${{ inputs.python-version >= '3.13' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -63,12 +62,20 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           allow-prereleases: true
+      - name: Check if Python is stable
+        id: python-is-stable
+        run: >
+          python
+          -c 'import sys; s = "stable" if (sys.version_info.releaselevel == "final") else ""; print(f"stable={s}")'
+          >>"$GITHUB_OUTPUT"
       - name: Install tox
         run: python -m pip install tox
       - name: Run script checks
+        continue-on-error: ${{!steps.python-is-stable.outputs.stable}}
         run: >
           tox -e script
       - name: Run tests
+        continue-on-error: ${{!steps.python-is-stable.outputs.stable}}
         # For simplicity, we limit forced minimum dependencies to direct
         # dependencies and build system dependencies, not extra dependencies
         # like pytest or sphinx.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,9 @@ jobs:
     runs-on: ${{ inputs.platform }}
     continue-on-error: ${{ inputs.python-version >= '3.13' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
           allow-prereleases: true

--- a/changelog.d/+python-prereleases.misc.rst
+++ b/changelog.d/+python-prereleases.misc.rst
@@ -1,0 +1,1 @@
+Dynamically determine which Python versions are prereleases and allowed to fail tests

--- a/changelog.d/+python314.misc.rst
+++ b/changelog.d/+python314.misc.rst
@@ -1,0 +1,1 @@
+Add testing for Python 3.14


### PR DESCRIPTION
The final beta of "πthon" (Python 3.14) is now available, so I'm adding it to the list of versions we test. It's not required to pass for now since 3.14 is not final.

As part of this change, I adjusted the test workflow to automatically determine whether it's using a prerelease version of Python, and if so, allow the tests to fail without failing the job as a whole.

I also fixed some pre-commit errors in the workflow file caused by old action versions.