### PR TITLE
Require changelog fragments in all PRs except changelog updates

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,0 +1,57 @@
+name: Pre-merge tests
+
+on:
+  pull_request:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: Check for a changelog fragment
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get changed files
+      id: changed-files
+      uses: step-security/changed-files@v46
+      with:
+        files: changelog.d/*.*
+    - name: Fail if no changelog fragment is present unless the changelog is being updated
+      env:
+        CHANGES_ADDED_FILES_COUNT: ${{steps.changed-files.outputs.added_files_count}}
+        CHANGES_DELETED_FILES_COUNT: ${{steps.changed-files.outputs.deleted_files_count}}
+        CHANGES_OTHER_MODIFIED_FILES: ${{steps.changed-files.outputs.other_modified_files}}
+      run: |
+        if [[ "$CHANGES_DELETED_FILES_COUNT" -eq 0 ]]; then
+          # Normal PR: a changelog fragment should be added
+          if [[ "$CHANGES_ADDED_FILES_COUNT" -gt 0 ]]; then
+            echo "::debug:: Found that a changelog file was added"
+            exit 0
+          else
+            echo "::error:: Please add a changelog fragment using towncrier"
+            exit 1
+          fi
+        else
+          # Changelog update PR: CHANGELOG.rst should be modified and changelog.d/!(.gitkeep) should be deleted
+          if [[ "$CHANGES_ADDED_FILES_COUNT" -gt 0 ]]; then
+            echo "::error:: Changelog fragments were both added and deleted"
+            exit 1
+          else
+            echo "::debug:: No changelog fragments were added"
+          fi
+          if [[ " $CHANGES_OTHER_MODIFIED_FILES " != *\ CHANGELOG.rst\ * ]]; then
+            echo "::error:: Changelog fragments were deleted but CHANGELOG.rst was not modified"
+            exit 1
+          else
+            echo "::debug:: Found that CHANGELOG.rst was modified"
+          fi
+          if [[ "$(git ls-files 'changelog.d/*.*')" != "changelog.d/.gitkeep" ]]; then
+            echo "::error:: Some but not all changelog fragments were deleted"
+            exit 1
+          else
+            echo "::debug:: Found that all changelog fragments were deleted"
+          fi
+        fi

--- a/changelog.d/+changelog-fragments-ci-check.misc.rst
+++ b/changelog.d/+changelog-fragments-ci-check.misc.rst
@@ -1,0 +1,1 @@
+Add a workflow to check for changelog fragments


### PR DESCRIPTION
Since it's easy to forget to include changelog fragments, I'm adding a workflow that will fail on any pull request that doesn't add a file under `changelog.d/`, unless it looks like it's regenerating the changelog (removing all fragments from `changelog.d` and updating `CHANGELOG.rst`). I'm not sure if this covers all the cases in which a pull request could legitimately not have a changelog fragment, but if not, we can add logic for more as we find them.

I tested the script in this PR by extracting it from the YAML file and piping to bash, with various combinations of the environment variables set.

I named the new workflow file `pre-merge.yaml` in anticipation of someday separating out pre-merge and post-merge tests into different workflows, but that's another story for another pull request.