### PR TITLE
Stop using a real filename for generated code in the console script

### DIFF
--- a/changelog.d/164.bugfix.rst
+++ b/changelog.d/164.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the coverage warning that came from using ``setup.py`` as the filename for a generated setup script

--- a/src/setuptools_pyproject_migration/cli.py
+++ b/src/setuptools_pyproject_migration/cli.py
@@ -63,7 +63,7 @@ def main() -> None:
             setup_code = f.read()
     else:
         setup_code = "import setuptools\nsetuptools.setup()\n"
-    setup_bytecode = compile(setup_code, "setup.py", "exec", dont_inherit=True)
+    setup_bytecode = compile(setup_code, "<setup.py>", "exec", dont_inherit=True)
     exec(setup_bytecode)
 
 


### PR DESCRIPTION
If our console script, `setuptools-pyproject-migration`, is run on a project that has `setup.cfg` but not `setup.py`, it uses a `compile()` call to simulate a bare-bones `setup.py` file, allowing us to essentially run a script that doesn't exist. However, when the console script is run in testing with coverage enabled, that causes a warning because coverage.py looks at the name given to `compile()` and expects to find a corresponding file on disk - but it doesn't exist.

To fix that issue and remove the warning, I'm switching the filename given to `compile()` to surround it with `<>`, as is typical when compiling code that didn't come from a real file. [coverage.py knows to recognize angle brackets around a filename and not look for a corresponding source file](https://github.com/nedbat/coveragepy/issues/1408#issuecomment-1159513546).

Closes #164