### PR TITLE
Require wheel-filename<2 to avoid import errors

### DIFF
--- a/changelog.d/+wheel-filename-1.bugfix.rst
+++ b/changelog.d/+wheel-filename-1.bugfix.rst
@@ -1,0 +1,1 @@
+Require ``wheel-filename<2`` to avoid import errors due to API changes in wheel-filename 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ testing =
 		python_version < "3.8"
 	importlib-metadata; \
 		python_version < "3.8"
-	wheel-filename
+	wheel-filename < 2
 	# pyproject-metadata 0.9.0 has breaking changes vs 0.8.1 and earlier.
 	pyproject-metadata >= 0.9.0
 	requests


### PR DESCRIPTION
In our tests we use the wheel-filename package, which recently released its major version 2, and that version includes API changes that break our test code. To prevent our tests from failing, I'm restricting wheel-filename to versions prior to 2.0 in this commit. A future commit will make the necessary changes for this package to work with wheel-filename 2. (The only reason I'm not doing that now is laziness, really :stuck_out_tongue: I want to make the quickest change that gets the code working again.)