### PR TITLE
Add vcs-versioning to the testing extra to address test failures

### DIFF
--- a/changelog.d/+vcs-versioning-workaround.bugfix.rst
+++ b/changelog.d/+vcs-versioning-workaround.bugfix.rst
@@ -1,0 +1,1 @@
+Add vcs-versioning to testing env dependencies to support distribution package tests using setuptools-scm>=10

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,11 @@ testing =
 	pyproject-metadata >= 0.9.0
 	requests
 	types-setuptools
+	# Temporary hack for distribution package testing: setuptools-scm>=10
+	# requires this as a dependency but setuptools' frontend doesn't
+	# install it
+	vcs-versioning; \
+		python_version >= "3.8"
 
 docs =
 	# upstream


### PR DESCRIPTION
We've been dealing with test failures (e.g. in #213) because the vcs_versioning module is not found in our distribution package tests. This commit implements a hopefully-temporary hack of adding vcs-versioning to the testing extra to resolve the problem. It works because the distribution packages we test with get installed into the same testing environment as this package itself.

The root cause of this appears to be that, when setuptools (in its role as a build frontend, i.e. the deprecated setup.py script) sets up the build environment for a package, it only installs the packages *directly* listed in the build_requires setuptools key, not their dependencies. But setuptools-scm>=10 added vcs-versioning as a non-vendored dependency, and so that dependency doesn't get installed by setuptools when setting up the build environment for the packages being tested.

I think a proper solution would involve creating isolated virtual environments for each distribution package test we run, but that's more work. I may do that later when I get time.

In the process of preparing this commit I used an LLM to automate some of the busy work of trying out different possible fixes.