### PR TITLE
Remove dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"

--- a/changelog.d/+dependabot.misc.rst
+++ b/changelog.d/+dependabot.misc.rst
@@ -1,0 +1,1 @@
+Disable Dependabot to avoid overconstraining dependencies


### PR DESCRIPTION
Dependabot has made a bunch of pull requests that constrain dependencies to extremely recent versions, but since those dependencies aren't actually built in to our program, we're not getting any security benefit from the stricter constraints. They just make it harder for consumers to use the package.

Since Dependabot isn't doing anything useful for us, I'm removing the configuration file to disable it.